### PR TITLE
Fix crash and add reconnect dialog when client loses server connection

### DIFF
--- a/game/utility/game_server/source/com/robin/game/server/GameClient.java
+++ b/game/utility/game_server/source/com/robin/game/server/GameClient.java
@@ -21,7 +21,9 @@ public abstract class GameClient extends GameNet {
 	public static final String DATA_NAME = "client";
 	
 	private static GameClient mostRecentClient = null;
-	
+
+	public enum DisconnectAction { RECONNECT, RESTART, EXIT }
+
 	private static Logger logger = Logger.getLogger(GameClient.class.getName());
 	
 	// Client messages
@@ -145,7 +147,7 @@ public abstract class GameClient extends GameNet {
 	public boolean isHosting() {
 		return hosting;
 	}
-	
+
 	public void addChangeListener(ChangeListener listener) {
 		if (changeListeners==null) {
 			changeListeners = new ArrayList();
@@ -320,8 +322,76 @@ public abstract class GameClient extends GameNet {
 		}
 	}
 	public void run() {
+		if (connection == null) {
+			if (!connectSocket()) {
+				fireStateChanged();
+				mostRecentClient = null;
+				return;
+			}
+		}
+
+		boolean running = true;
+		while (running) {
+			running = false;
+			try {
+				send(REQUEST_LOGIN);
+				String password = (String)getInputStream().readObject();
+
+				if (clientPass.equals(password)) {
+					logger.info("GameClient "+clientName+": logged in");
+					doRequest(new RequestObject(SUBMIT_LOGIN));
+					connected = true;
+					fireStateChanged();
+
+					logger.info("GameClient "+clientName+": main loop started");
+					while(!timeToLeave()) {
+						doRequest(getNextInQueue());
+						while(requestQueue.size()>0) {
+							doRequest(getNextInQueue());
+						}
+					}
+				}
+				else {
+					JOptionPane.showMessageDialog(null,"Invalid Password","Login Error",JOptionPane.ERROR_MESSAGE);
+					leave = true;
+				}
+				try {
+					send(SUBMIT_GOODBYE);
+					if (in != null) in.close();
+					if (out != null) out.close();
+					connection.close();
+				}
+				catch(SocketException ex) {
+					// ignore
+				}
+				catch(IOException ex) {
+					// ignore
+				}
+				connected = false;
+				fireStateChanged();
+			}
+			catch(SocketTimeoutException ex) {
+				System.err.println("Timed out!");
+				ex.printStackTrace();
+				running = onDisconnected();
+			}
+			catch(IOException ex) {
+				ex.printStackTrace();
+				running = onDisconnected();
+			}
+			catch(Exception ex) {
+				ex.printStackTrace();
+				running = onDisconnected();
+			}
+		}
+
+		clientDead = true;
+		mostRecentClient = null;
+	}
+
+	private boolean connectSocket() {
 		int attempts = 0;
-		while(connection==null && (attempts++)<5) { // only try 5 times
+		while (connection==null && (attempts++)<5) {
 			if (ipAddress==null) {
 				mostRecentClient = null;
 				throw new IllegalStateException("Can't start an unconnected GameClient with a null ipAddress!!!");
@@ -333,82 +403,78 @@ public abstract class GameClient extends GameNet {
 				logger.info("Client connected");
 			}
 			catch(IOException ex) {
-				// Server might not be ready yet...  wait a half-second and try again
 				connection = null;
 				try {
 					Thread.sleep(500);
 				}
 				catch(InterruptedException iex) {
-					// this would be bad, so exit here
 					iex.printStackTrace();
 					mostRecentClient = null;
-					return; // This ends the thread
+					return false;
 				}
 			}
 		}
-		
-		if (connection==null) {
-			// Couldn't get a good connection - ever.
-			fireStateChanged();
-			mostRecentClient = null;
-			return; // This ends the thread
-		}
+		return connection != null;
+	}
 
-		try {
-			// Do login first
-			send(REQUEST_LOGIN);
-			String password = (String)getInputStream().readObject();
-			
-			if (clientPass.equals(password)) {
-				logger.info("GameClient "+clientName+": logged in");
-				// Send name information
-				doRequest(new RequestObject(SUBMIT_LOGIN));
-				connected = true;
-				
-				fireStateChanged();
-				
-				// Now, loop through queue
-				logger.info("GameClient "+clientName+": main loop started");
-				while(!timeToLeave()) {
-					doRequest(getNextInQueue());
-					
-					// Process any other requests in the queue, if there are any
-					while(requestQueue.size()>0) {
-						doRequest(getNextInQueue());
-					}
-//if ((beeper++)%10==0) {System.out.println("BEEP! "+beeper);}					
+	private boolean onDisconnected() {
+		switch (handleDisconnect()) {
+			case RECONNECT:
+				resetForReconnect();
+				if (ipAddress != null && !connectSocket()) {
+					JOptionPane.showMessageDialog(null,"Unable to reach server at "+ipAddress+".","Reconnect Failed",JOptionPane.ERROR_MESSAGE);
+					leave = true;
+					connected = false;
+					fireStateChanged();
+					return false;
 				}
-			}
-			else {
-				JOptionPane.showMessageDialog(null,"Invalid Password","Login Error",JOptionPane.ERROR_MESSAGE);
-			}
-			try {
-				send(SUBMIT_GOODBYE);
-				in.close();
-				out.close();
-				connection.close();
-			}
-			catch(SocketException ex) {
-				// ignore
-			}
-			catch(IOException ex) {
-				// ignore
-			}
-			connected = false;
-			fireStateChanged();
+				return true;
+			case RESTART:
+				leave = true;
+				connected = false;
+				fireStateChanged();
+				return false;
+			case EXIT:
+			default:
+				System.exit(0);
+				return false;
 		}
-		catch(SocketTimeoutException ex) {
-			System.err.println("Timed out!");
-			ex.printStackTrace();
+	}
+
+	protected DisconnectAction handleDisconnect() {
+		final DisconnectAction[] result = {DisconnectAction.EXIT};
+		try {
+			SwingUtilities.invokeAndWait(() -> {
+				Object[] options = {"Reconnect","Restart","Exit"};
+				int choice = JOptionPane.showOptionDialog(
+					null,
+					"Lost connection to server" + (ipAddress != null ? " ("+ipAddress+")" : "") + ".",
+					"Disconnected",
+					JOptionPane.YES_NO_CANCEL_OPTION,
+					JOptionPane.WARNING_MESSAGE,
+					null,
+					options,
+					options[0]);
+				if (choice == 0) result[0] = DisconnectAction.RECONNECT;
+				else if (choice == 1) result[0] = DisconnectAction.RESTART;
+			});
 		}
 		catch(Exception ex) {
 			ex.printStackTrace();
 		}
-		
-		clientDead = true;
-		
-		 // This ends the thread
-		mostRecentClient = null;
+		return result[0];
+	}
+
+	private void resetForReconnect() {
+		in = null;
+		out = null;
+		connection = null;
+		connected = false;
+		dataLoaded = false;
+		requestQueue.clear();
+		waitingSubmit = false;
+		gameData.rebuildChanges();
+		gameData.setTracksChanges(true);
 	}
 	private void doRequest(RequestObject ro) throws SocketTimeoutException,Exception {
 		send(ro.getRequest());

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
@@ -1901,13 +1901,27 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 
 	public void submitChanges() {
 		logger.finer("submitChanges()");
-		GameClient.submitAndWait(client);
+		try {
+			GameClient.submitAndWait(client);
+		}
+		catch(RuntimeException ex) {
+			logger.warning("submitChanges failed - client disconnected: " + ex.getMessage());
+			parent.killHandler();
+			return;
+		}
 		characterTable.repaint();
 	}
-	
+
 	public void submitChangesWithTimeout() {
-		logger.finer("submitChanges()");
-		client.submitWithTimeout();
+		logger.finer("submitChangesWithTimeout()");
+		try {
+			client.submitWithTimeout();
+		}
+		catch(RuntimeException ex) {
+			logger.warning("submitChangesWithTimeout failed - client disconnected: " + ex.getMessage());
+			parent.killHandler();
+			return;
+		}
 		characterTable.repaint();
 	}
 
@@ -2204,7 +2218,13 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 
 	private ActionListener clientSubmitter = new ActionListener() {
 		public void actionPerformed(ActionEvent ev) {
-			GameClient.submitAndWait(client);
+			try {
+				GameClient.submitAndWait(client);
+			}
+			catch(RuntimeException ex) {
+				logger.warning("clientSubmitter failed - client disconnected: " + ex.getMessage());
+				parent.killHandler();
+			}
 		}
 	};
 


### PR DESCRIPTION
When the server connection dropped, submitChanges() threw "This client is DEAD!" crashing the game. GameClient now shows a Reconnect/Restart/Exit dialog on disconnect and loops back into the main run loop on reconnect. RealmGameHandler catches the RuntimeException from submitChanges/submitChangesWithTimeout and clientSubmitter, calling killHandler() gracefully instead of crashing.