### PR TITLE
Fix .rschar temp file collision between concurrent instances

### DIFF
--- a/general/utility/general_io/source/com/robin/general/io/ZipUtilities.java
+++ b/general/utility/general_io/source/com/robin/general/io/ZipUtilities.java
@@ -15,6 +15,9 @@ public class ZipUtilities {
 	 * @return				An array of File objects, describing what was unzipped
 	 */
 	public static File[] unzip(File zipFile) {
+		return unzip(zipFile, new File(FileUtilities.getFilePathString(zipFile, false, false)));
+	}
+	public static File[] unzip(File zipFile, File destDir) {
 		lastError = null;
 		File[] files = null;
 		try {
@@ -27,9 +30,8 @@ public class ZipUtilities {
 //				System.out.println("Extracting: " + entry);
 				int count;
 				byte data[] = new byte[BUFFER];
-				
-				// write the file to disk, in the same directory as zipFile
-				String filePath = FileUtilities.getFilePathString(zipFile,false,false)+entry.getName();
+
+				String filePath = destDir.getAbsolutePath() + File.separator + entry.getName();
 				fileList.add(new File(filePath));
 				FileOutputStream fos = new FileOutputStream(filePath);
 				dest = new BufferedOutputStream(fos, BUFFER);

--- a/magic_realm/applications/RealmCharacterBuilder/source/com/robin/magic_realm/RealmCharacterBuilder/RealmCharacterBuilderModel.java
+++ b/magic_realm/applications/RealmCharacterBuilder/source/com/robin/magic_realm/RealmCharacterBuilder/RealmCharacterBuilderModel.java
@@ -2,6 +2,7 @@ package com.robin.magic_realm.RealmCharacterBuilder;
 
 import java.awt.image.BufferedImage;
 import java.io.*;
+import java.nio.file.Files;
 import java.util.*;
 
 import javax.imageio.ImageIO;
@@ -540,16 +541,23 @@ public class RealmCharacterBuilderModel {
 		return gameData;
 	}
 	public static RealmCharacterBuilderModel createFromFile(File file) {
-		// load it
-		File[] files = ZipUtilities.unzip(file);
+		// Extract to a unique temp dir so concurrent instances don't collide on shared filenames
+		File tempDir;
+		try {
+			tempDir = Files.createTempDirectory("rschar_").toFile();
+		} catch (IOException ex) {
+			throw new RealmCharacterException("Unable to create temp dir for "+file.getAbsolutePath()+": "+ex);
+		}
+		File[] files = ZipUtilities.unzip(file, tempDir);
 		if (files==null) {
 			throw new RealmCharacterException("Unable to open "+file.getAbsolutePath()+":  "+ZipUtilities.lastError);
 		}
-		
+
 		// Make sure all the files will be deleted no matter what happens
 		for (int i=0;i<files.length;i++) {
 			files[i].deleteOnExit();
 		}
+		tempDir.deleteOnExit();
 		
 		RealmCharacterBuilderModel model = null;
 		// First, get the XML file, so the model can be created


### PR DESCRIPTION
## Summary
- `ZipUtilities.unzip()` extracted character files to the same directory as the source `.rschar` file, so all instances wrote to the same `characters/_RCB2212_character.xml` temp path
- Two instances starting simultaneously would overwrite each other's temp XML mid-parse, causing `JDOMParseException` with varying line numbers
- Added `ZipUtilities.unzip(File, File destDir)` overload; `createFromFile()` now extracts each `.rschar` to a unique `Files.createTempDirectory()` path

## Test plan
- [x] Start two instances simultaneously from a clean release zip
- [x] Confirm no `Invalid file/format` / JDOMParseException dialog on startup
- [x] Confirm custom characters load correctly in both instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)