### PR TITLE
Show connection info in window title (opt-in)

### DIFF
--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
@@ -227,6 +227,17 @@ public class CombatFrame extends JFrame {
 	public static boolean isSingletonShowing() {
 		return singleton!=null && singleton.isVisible();
 	}
+	public void updateConnectionTitle(boolean showInfo, String ip, int port) {
+		if (showInfo) {
+			if (ip == null) {
+				setTitle("RealmSpeak Combat Frame for " + playerName + " (Local)");
+			} else {
+				setTitle("RealmSpeak Combat Frame for " + playerName + " @ " + ip + ":" + port);
+			}
+		} else {
+			setTitle("RealmSpeak Combat Frame for " + playerName);
+		}
+	}
 	public static CombatFrame getSingleton() {
 		return singleton;
 	}

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
@@ -2169,6 +2169,7 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 			if (interactiveCharacter != null) {
 				showCharacterFrame(interactiveCharacter);
 				boolean did = CombatFrame.doDisplayInteractive(getMainFrame(), client.getGameData(), client.getClientName(), clientSubmitter, local, isHostPlayer());
+				getMainFrame().updateConnectionTitle();
 				if (!did) {
 					needSubmit = true;
 				}
@@ -2176,6 +2177,7 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 			else {
 				// Observation only mode!
 				CombatFrame.doDisplayObserving(getMainFrame(), client.getGameData(), client.getClientName(), clientSubmitter, local, isHostPlayer());
+				getMainFrame().updateConnectionTitle();
 			}
 		}
 		else {

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakFrame.java
@@ -85,8 +85,12 @@ public class RealmSpeakFrame extends JFrameWithStatus {
 	protected GameHost host = null;
 	protected RealmHostPanel realmHostFrame = null;
 	protected RealmGameHandler gameHandler = null;
-	
+
 	protected File lastSaveGame = null;
+
+	private String connectedName = null;
+	private String connectedIp = null;
+	private int connectedPort = 0;
 	
 	protected ArrayList<RealmSpeakInternalFrame> gameControlFrames;
 	protected ArrayList<CharacterFrame> characterFrames;
@@ -2203,23 +2207,37 @@ public class RealmSpeakFrame extends JFrameWithStatus {
 	}
 	
 	public void startRealmGameHandler(String ip,int port,String name,String pass,String ppass,String email,boolean hostPlayer) {
+		connectedName = name;
+		connectedIp = ip;
+		connectedPort = port;
 		if (ip==null) {
 			// Non-network game (local)
 			gameHandler = new RealmGameHandler(this,host,name,pass,ppass,email);
-			if (realmSpeakOptions.getOptions().getBoolean(RealmSpeakOptions.SHOW_CONNECTION_INFO,false)) {
-				setTitle(Constants.APPLICATION_NAME+" - "+name+" (Local)");
-			}
 		}
 		else {
-			// Network game (hosting)
+			// Network game (remote)
 			gameHandler = new RealmGameHandler(this,ip,port,name,pass,ppass,email,hostPlayer);
-			if (realmSpeakOptions.getOptions().getBoolean(RealmSpeakOptions.SHOW_CONNECTION_INFO,false)) {
-				setTitle(Constants.APPLICATION_NAME+" - "+name+" @ "+ip+":"+port);
-			}
 		}
+		updateConnectionTitle();
 		gameHandler.updateToolbarOptions(realmSpeakOptions.getActionIconState());
 		addFrameToDesktop(gameHandler);
 		updateControls();
+	}
+	public void updateConnectionTitle() {
+		boolean showInfo = connectedName != null && realmSpeakOptions.getOptions().getBoolean(RealmSpeakOptions.SHOW_CONNECTION_INFO,false);
+		if (showInfo) {
+			if (connectedIp == null) {
+				setTitle(Constants.APPLICATION_NAME+" - "+connectedName+" (Local)");
+			} else {
+				setTitle(Constants.APPLICATION_NAME+" - "+connectedName+" @ "+connectedIp+":"+connectedPort);
+			}
+		} else {
+			setTitle(Constants.APPLICATION_NAME);
+		}
+		CombatFrame combatFrame = CombatFrame.getSingleton();
+		if (combatFrame != null) {
+			combatFrame.updateConnectionTitle(showInfo, connectedIp, connectedPort);
+		}
 	}
 	public void showStatus(String val) {
 		status.setText(val);
@@ -2242,8 +2260,11 @@ public class RealmSpeakFrame extends JFrameWithStatus {
 			if (ret!=JOptionPane.YES_OPTION) {
 				return false;
 			}
-			setTitle("Realm Speak");
-			
+			connectedName = null;
+			connectedIp = null;
+			connectedPort = 0;
+			setTitle(Constants.APPLICATION_NAME);
+
 			// Now to kill the game
 			RealmUtility.resetGame();
 			CombatFrame.resetSingleton();

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakFrame.java
@@ -2128,8 +2128,6 @@ public class RealmSpeakFrame extends JFrameWithStatus {
 		// Launch a game connection frame
 		realmHostFrame = new RealmHostPanel(host,netConnect);
 		
-		setTitle("Realm Speak"+(netConnect?" (Hosting)":" (Local)"));
-	
 		// This works well, even though it technically doubles the resources on the host machine.
 		// Probably not worth the effort to change, unless memory becomes an issue.
 		String ip = null;
@@ -2208,10 +2206,16 @@ public class RealmSpeakFrame extends JFrameWithStatus {
 		if (ip==null) {
 			// Non-network game (local)
 			gameHandler = new RealmGameHandler(this,host,name,pass,ppass,email);
+			if (realmSpeakOptions.getOptions().getBoolean(RealmSpeakOptions.SHOW_CONNECTION_INFO,false)) {
+				setTitle(Constants.APPLICATION_NAME+" - "+name+" (Local)");
+			}
 		}
 		else {
 			// Network game (hosting)
 			gameHandler = new RealmGameHandler(this,ip,port,name,pass,ppass,email,hostPlayer);
+			if (realmSpeakOptions.getOptions().getBoolean(RealmSpeakOptions.SHOW_CONNECTION_INFO,false)) {
+				setTitle(Constants.APPLICATION_NAME+" - "+name+" @ "+ip+":"+port);
+			}
 		}
 		gameHandler.updateToolbarOptions(realmSpeakOptions.getActionIconState());
 		addFrameToDesktop(gameHandler);

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakOptionPanel.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakOptionPanel.java
@@ -83,6 +83,7 @@ public class RealmSpeakOptionPanel extends JDialog {
 	protected JRadioButton dailyCombatOnSpellcastersOption;
 	
 	protected JCheckBox enableSoundItem;
+	protected JCheckBox showConnectionInfoOption;
 	protected JSlider adjustVolumeItem;
 	
 	private RealmSpeakFrame mainFrame;
@@ -240,7 +241,8 @@ public class RealmSpeakOptionPanel extends JDialog {
 		showCombatNextWarningOption.setSelected(options.getOptions().getBoolean(RealmSpeakOptions.COMBAT_NEXT_PHASE_WARNING,true));
 		autoPositioningAttackersOption.setSelected(options.getOptions().getBoolean(RealmSpeakOptions.AUTO_POSITIONING_ATTACKERS,false));
 		characterlistSortingByPlayOrder.setSelected(options.getOptions().getBoolean(RealmSpeakOptions.CHARACTERLIST_SORTING_BY_PLAY_ORDER,true));
-		
+		showConnectionInfoOption.setSelected(options.getOptions().getBoolean(RealmSpeakOptions.SHOW_CONNECTION_INFO,false));
+
 		boolean sound = options.getOptions().getBoolean(RealmSpeakOptions.ENABLE_SOUND,true);
 		enableSoundItem.setSelected(sound);
 		adjustVolumeItem.setEnabled(sound);
@@ -285,6 +287,7 @@ public class RealmSpeakOptionPanel extends JDialog {
 		options.getOptions().set(RealmSpeakOptions.COMBAT_NEXT_PHASE_WARNING,showCombatNextWarningOption.isSelected());
 		options.getOptions().set(RealmSpeakOptions.AUTO_POSITIONING_ATTACKERS,autoPositioningAttackersOption.isSelected());
 		options.getOptions().set(RealmSpeakOptions.CHARACTERLIST_SORTING_BY_PLAY_ORDER,characterlistSortingByPlayOrder.isSelected());
+		options.getOptions().set(RealmSpeakOptions.SHOW_CONNECTION_INFO,showConnectionInfoOption.isSelected());
 		options.getOptions().set(RealmSpeakOptions.ENABLE_SOUND,enableSoundItem.isSelected());
 		mainFrame.saveFramePreferences();
 	}
@@ -644,8 +647,10 @@ public class RealmSpeakOptionPanel extends JDialog {
 		return panel;
 	}
 	private JPanel getPopupWindowOptions() {
-		JPanel panel = new JPanel(new GridLayout(9,1));
+		JPanel panel = new JPanel(new GridLayout(10,1));
 		panel.setBorder(BorderFactory.createTitledBorder("Notifications"));
+		showConnectionInfoOption = new JCheckBox("Show connection info in window title");
+		panel.add(showConnectionInfoOption);
 		showHeavyInvWarningOption = new JCheckBox("Show Heavy Inventory Warning");
 		panel.add(showHeavyInvWarningOption);
 		showIncompleteRecordWarningOption = new JCheckBox("Show Incomplete Recording Warning");

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakOptions.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakOptions.java
@@ -56,6 +56,7 @@ public class RealmSpeakOptions {
 	public static final String AUTO_POSITIONING_ATTACKERS = "autoPositioningAttackers";
 	public static final String CHARACTERLIST_SORTING_BY_PLAY_ORDER = "characterlistSortingByPlayOrder";
 	public static final String ENABLE_SOUND = "enableSound";
+	public static final String SHOW_CONNECTION_INFO = "showConnectionInfo";
 	
 	PreferenceManager options;
 	

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakOptions.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakOptions.java
@@ -148,6 +148,7 @@ public class RealmSpeakOptions {
 		}
 		CustomUiUtility.initColors();
 		SwingUtilities.updateComponentTreeUI(frame);
+		frame.updateConnectionTitle();
 	}
 	private void readFramePreferences() {
 		options = RealmUtility.getRealmSpeakPrefs();


### PR DESCRIPTION
## Summary

- Adds a **Show connection info in window title** option (off by default) in the Options dialog
- When enabled, the main window title changes to `RealmSpeak - name (Local)` for local games and `RealmSpeak - name @ ip:port` for network games
- The combat frame title similarly shows `RealmSpeak Combat Frame for name (Local)` or `name @ ip:port`
- Toggling the option immediately updates all window titles without requiring a reconnect

## Motivation

When running multiple instances on the same machine (one or more servers + one or more clients), all windows are titled identically in regards to which game the window targets. This option makes it easy to identify which instance is which at a glance.  Both multiple servers (for different games, and multiple clients is a use case I use at least, and the windows proliferate a bit.  Very handy to make it easier to sort out which are for which game.


## Test plan

- [x] Start a local game with option off — title stays `RealmSpeak`
- [x] Enable option in Options dialog — title immediately updates to `RealmSpeak - name (Local)`
- [x] Disable option — title immediately reverts to `RealmSpeak`
- [x] Join a network game with option on — title shows `RealmSpeak - name @ ip:port`
- [x] Trigger combat — combat frame title shows connection info if option is on
- [x] Shut down game — title resets to plain `RealmSpeak`

🤖 Generated with [Claude Code](https://claude.com/claude-code)