### PR TITLE
Fix duplicate fatigue/wound dialogs at end of battle round

### DIFF
--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
@@ -4634,14 +4634,29 @@ public class CombatFrame extends JFrame {
 	}
 	private synchronized static void doFatigueWounds(JFrame parent,CharacterWrapper character) {
 		CombatWrapper combat = new CombatWrapper(character.getGameObject());
-		
+
+		// Read and immediately clear HEALING and NEW_WOUNDS before showing any dialogs.
+		//
+		// This method is synchronized, so concurrent callers queue up rather than being
+		// skipped. Without clearing first, a queued second caller (e.g. checkRunAway()
+		// followed by the static doDisplay() COMBAT_FATIGUE path, or two clients racing in
+		// multiplayer) would read the same non-zero values and re-show all the dialogs,
+		// causing the player to fill out fatigue/wound assignments multiple times for the
+		// same hit. Clearing on entry means the second caller sees zero for both and exits
+		// each dialog block immediately.
+		//
+		// weatherFatigue is already cleared inside doFatigueWeather() after its dialog,
+		// and effortUsed is derived fresh from chit state, so neither needs clearing here.
 		int healing = combat.getHealing(); // i.e., Drain Life
+		combat.clearHealing();
+		int newWounds = combat.getNewWounds();
+		combat.clearNewWounds();
+
 		if (healing>0) {
 			broadcastMessage(character.getGameObject().getName(),"Healing "+healing+" asterisk"+(healing==1?"":"s")+".");
 			ChitRestManager rester = new ChitRestManager(parent,character,healing);
 			rester.setVisible(true);
 		}
-		int newWounds = combat.getNewWounds();
 		Effort effortUsed = BattleUtility.getEffortUsed(character);
 		int free = character.getEffortFreeAsterisks();
 		int needToFatigue = effortUsed.getNeedToFatigue(free);

--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/wrapper/CombatWrapper.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/wrapper/CombatWrapper.java
@@ -546,6 +546,9 @@ public class CombatWrapper extends GameObjectWrapper {
 	public int getNewWounds() {
 		return getInt(NEW_WOUNDS);
 	}
+	public void clearNewWounds() {
+		getGameObject().removeAttribute(COMBAT_BLOCK,NEW_WOUNDS);
+	}
 	public void setKilledByWounds(boolean val) {
 		setBoolean(KILLED_BY_WOUNDS,val);
 	}
@@ -558,6 +561,9 @@ public class CombatWrapper extends GameObjectWrapper {
 	}
 	public int getHealing() {
 		return getInt(HEALING);
+	}
+	public void clearHealing() {
+		getGameObject().removeAttribute(COMBAT_BLOCK,HEALING);
 	}
 	public void setWasFatigue(boolean val) {
 		setBoolean(WAS_FATIGUE,val); // only used by tile to track fatigue by characters running away this round


### PR DESCRIPTION
In a recent multiplayer game, a battling character had both fatigue and wound dialogs appear at the same time, and when he filled them out, they would just reappear again asking to do the same thing, after the 3rd or 4th repetition of this, the dialogs actually resolved (which surprised me, as i thought it was in an endless loop of some sort.  Anyways, the game continued and I went back to investigate later.  Claude thinks it has resolved the issue, and it look reasonable to me.

See what you think.

Trying to repeat the issue in old build and see it not happening with this fix in place, but may be difficult...

Summary:

doFatigueWounds() is synchronized, so concurrent callers (e.g. checkRunAway() and the static doDisplay() COMBAT_FATIGUE path firing for the same character in the same round, or racing clients in multiplayer) queue up rather than skip. HEALING and NEW_WOUNDS were never cleared after the dialogs, so the queued second caller read the same non-zero values and re-showed all dialogs, forcing the player to fill out fatigue and wound assignments multiple times for the same hit.

Fix: read and immediately clear both values on entry to doFatigueWounds() before any dialog is shown. A queued second caller then sees zero for both and skips the dialog blocks. weatherFatigue is already cleared inside doFatigueWeather() after its own dialog; effortUsed is derived fresh from chit state each call, so neither requires the same treatment.

Add clearHealing() and clearNewWounds() to CombatWrapper alongside the existing clear() bulk-removal to support targeted clearing here.