### PR TITLE
Fix race condition NPE in GameObject.startUncommitted()

### DIFF
--- a/game/utility/game_objects/source/com/robin/game/objects/GameObject.java
+++ b/game/utility/game_objects/source/com/robin/game/objects/GameObject.java
@@ -90,28 +90,40 @@ public class GameObject extends ModifyableObject implements Serializable {
 	}
 
 	private void startUncommitted() {
-		// Builds the uncommitted object to look just like this object in every respect
-		uncommitted = new GameObject();
-		uncommitted.id = this.id;
-		uncommitted.setName(name); // so that keyval searches with name actually work!!
-		uncommitted._setVersion(version);
+		// Builds the uncommitted object to look just like this object in every respect.
+		//
+		// THREADING: this.uncommitted is read by stopUncommitted() on whatever thread calls
+		// commit() or rollback(), which can race with this method running on a different thread
+		// (e.g. the GameServer thread calling serverLost() -> setMissingInAction() while the
+		// EDT or another server thread is mid-commit). The original code assigned
+		// "uncommitted = new GameObject()" on the first line and then read the field throughout
+		// the setup loop; a concurrent stopUncommitted() call setting "uncommitted = null" between
+		// those two points produced a NullPointerException at the getAttributeBlock() calls.
+		//
+		// Fix: build the snapshot entirely via a local variable and publish it to the field only
+		// once, at the very end. Concurrent stopUncommitted() calls that null this.uncommitted
+		// during the loop are harmless — we are not reading the field, only writing it once done.
+		GameObject local = new GameObject();
+		local.id = this.id;
+		local.setName(name); // so that keyval searches with name actually work!!
+		local._setVersion(version);
 		for (String blockName : attributeBlocks.keySet()) {
 			OrderedHashtable<String,OrderedHashtable> attributes = attributeBlocks.get(blockName);
 			for (String attributeKey : attributes.keySet()) {
 				Object value = attributes.get(attributeKey);
 				if (value instanceof String) {
-					uncommitted.getAttributeBlock(blockName).put(attributeKey, value);
+					local.getAttributeBlock(blockName).put(attributeKey, value);
 				}
 				else {
-					uncommitted.getAttributeBlock(blockName).put(attributeKey, new ArrayList((Collection) value));
+					local.getAttributeBlock(blockName).put(attributeKey, new ArrayList((Collection) value));
 				}
 			}
 		}
-		uncommitted.heldBy = heldBy;
-		uncommitted.hold.addAll(hold);
-		uncommitted.holdIds.addAll(holdIds);
-		
-		uncommitted.copyChangeListeners(this);
+		local.heldBy = heldBy;
+		local.hold.addAll(hold);
+		local.holdIds.addAll(holdIds);
+		local.copyChangeListeners(this);
+		uncommitted = local;
 	}
 
 	public void rollback() {


### PR DESCRIPTION
## Problem

When a client disconnects mid-combat, the server's disconnect handler calls:

```
GameServer.run() → removeServer() → fireServerLost() → serverLost()
  → setMissingInAction() → setAttribute() → startUncommitted()
```

This runs on the `GameServer` thread. If the EDT or another server thread concurrently calls `stopUncommitted()` (which sets `this.uncommitted = null`) on the same `GameObject`, the original code NPE'd inside `startUncommitted()`:

```
NullPointerException: "this.uncommitted" is null
  at GameObject.startUncommitted(GameObject.java:103)
  at GameObject.setAttribute(...)
  at CharacterWrapper.setMissingInAction(...)
  at RealmHostPanel$3.serverLost(...)
  at GameHost.removeServer(...)
  at GameServer.run(...)
```

The original code assigned `uncommitted = new GameObject()` on the first line of `startUncommitted()` and then read the field throughout the setup loop. `stopUncommitted()` sets `uncommitted = null` unconditionally with no synchronization, so a concurrent call landing anywhere in that loop caused the crash.

This left the other clients in a broken state — End Combat responses were lost and clients received a "server was shut down" message. The bug was intermittent because the race window is small; it became reliably reproducible with 4+ combatants at end-of-combat due to the volume of concurrent state changes at that moment.

## Fix

Build the snapshot entirely via a local variable and publish to `this.uncommitted` only once, at the very end of `startUncommitted()`. A concurrent `stopUncommitted()` nulling the field during construction is now harmless — the field is not read during setup, only written once the object is fully built. This also eliminates the previous exposure of a half-constructed object to other threads: `uncommitted` is now either `null` or fully initialized, never partially built.

## Testing

- [x] **Multiplayer state sync** — after combat, verify wounds, fatigue, gold, and fame propagate correctly to all clients. A regression here would show as stale state on one client.
- [x] **End-of-round cleanup with 4+ combatants** — run a full combat round to completion including fatigue and wound dialogs; previously this was the scenario most likely to hit the race.
- [x] **End Combat flow** — have all combatants click End and confirm the responses all register correctly without dialogs disappearing or "server was shut down" appearing.
- [x] **Client disconnect mid-game (non-combat)** — drop a client during daylight; the remaining clients should continue normally and the disconnected character should be marked missing-in-action without a server crash.
- [x] **Rollback / undo** — exercise any action that triggers a rollback (e.g. cancelling a spell) and confirm state reverts correctly.
- [x] **Save and reload** — save after a combat round and confirm the game reloads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)