### PR TITLE
Fix End Combat dialog freezing game when players take too long to respond

### DIFF
--- a/game/utility/game_server/source/com/robin/game/server/GameHost.java
+++ b/game/utility/game_server/source/com/robin/game/server/GameHost.java
@@ -204,13 +204,15 @@ public class GameHost {
 		//
 		// WHY: fireHostModified() calls updateGame() on RealmHostPanel, which runs
 		// updateGameState() (full game-state machine) and may trigger autosave (zipToFile).
-		// Both can take seconds. While that work ran inside a synchronized method, every
-		// other GameServer thread trying to respond to REQUEST_IDLE was blocked on
-		// getMasterToGameChanges() waiting for the same lock. After 10 s the clients'
-		// SO_TIMEOUT fired, disconnecting them and leaving combat permanently frozen.
+		// Both can take seconds. While that work ran inside a synchronized method, any
+		// concurrent call to applyChanges() from another GameServer thread (servicing a
+		// SUBMIT_CHANGES from its client) would block on the GameHost lock until the slow
+		// host-panel update finished. Similarly, a newly connecting client whose REQUEST_IDLE
+		// triggers getMasterToGameChanges() (also synchronized on GameHost) would block
+		// during that window.
 		//
-		// Releasing the lock before the notification means getMasterToGameChanges() is
-		// never blocked by slow host-panel work, so the 10 s timeout is never hit.
+		// Releasing the lock before fireHostModified() means concurrent applyChanges() calls
+		// and getMasterToGameChanges() calls are never held up by slow host-panel work.
 		boolean shouldFire = false;
 		synchronized(this) {
 			if (changes!=null && !changes.isEmpty()) {
@@ -247,7 +249,7 @@ public class GameHost {
 			}
 		}
 		// GameHost lock is released — fireHostModified/updateGame may be slow but will
-		// no longer block other GameServer threads from servicing REQUEST_IDLE.
+		// no longer block concurrent applyChanges() or getMasterToGameChanges() calls.
 		if (shouldFire) {
 			fireHostModified();
 		}

--- a/game/utility/game_server/source/com/robin/game/server/GameHost.java
+++ b/game/utility/game_server/source/com/robin/game/server/GameHost.java
@@ -195,42 +195,61 @@ public class GameHost {
 		return gameData.getGameObject(id);
 	}
 	
-	public synchronized boolean applyChanges(GameServer activeServer,ArrayList<GameObjectChange> changes) {
+	public boolean applyChanges(GameServer activeServer,ArrayList<GameObjectChange> changes) {
 		return applyChanges(activeServer,changes,true);
 	}
-	public synchronized boolean applyChanges(GameServer activeServer,ArrayList<GameObjectChange> changes,boolean fireChange) {
-		if (changes!=null && !changes.isEmpty()) {
-//			for (Iterator i=changes.iterator();i.hasNext();) {
-//				GameObjectChange change = (GameObjectChange)i.next();
-//				if (!change.testVersion(gameData)) {
-//					// Version inconsistency
-//					return false;
+	public boolean applyChanges(GameServer activeServer,ArrayList<GameObjectChange> changes,boolean fireChange) {
+		// Apply changes and distribute to peer servers while holding the GameHost lock,
+		// then release the lock before calling fireHostModified().
+		//
+		// WHY: fireHostModified() calls updateGame() on RealmHostPanel, which runs
+		// updateGameState() (full game-state machine) and may trigger autosave (zipToFile).
+		// Both can take seconds. While that work ran inside a synchronized method, every
+		// other GameServer thread trying to respond to REQUEST_IDLE was blocked on
+		// getMasterToGameChanges() waiting for the same lock. After 10 s the clients'
+		// SO_TIMEOUT fired, disconnecting them and leaving combat permanently frozen.
+		//
+		// Releasing the lock before the notification means getMasterToGameChanges() is
+		// never blocked by slow host-panel work, so the 10 s timeout is never hit.
+		boolean shouldFire = false;
+		synchronized(this) {
+			if (changes!=null && !changes.isEmpty()) {
+//				for (Iterator i=changes.iterator();i.hasNext();) {
+//					GameObjectChange change = (GameObjectChange)i.next();
+//					if (!change.testVersion(gameData)) {
+//						// Version inconsistency
+//						return false;
+//					}
 //				}
-//			}
-			logger.fine("Host apply changes: "+changes.size()+" changes.");
-			for (GameObjectChange action : changes) {
-				logger.finer("--> "+action);
-				action.applyChange(gameData);
-			}
-//			gameData.rebuildChanges(); // This breaks things fairly badly!
-			logger.fine("Host apply changes: DONE.");
-			
-			// Update all servers (except the originating server) with the changes
-			ArrayList<GameServer> serversToUpdate = new ArrayList<>();
-			serversToUpdate.addAll(servers);
-			for (GameServer server:serversToUpdate) {
-				logger.fine("activeServer="+activeServer);
-				logger.fine("server="+server);
-				if (activeServer==null || !server.equals(activeServer)) {
-					logger.fine("updating a server with "+changes.size());
-					server.addObjectChanges(changes);
+				logger.fine("Host apply changes: "+changes.size()+" changes.");
+				for (GameObjectChange action : changes) {
+					logger.finer("--> "+action);
+					action.applyChange(gameData);
+				}
+//				gameData.rebuildChanges(); // This breaks things fairly badly!
+				logger.fine("Host apply changes: DONE.");
+
+				// Update all servers (except the originating server) with the changes
+				ArrayList<GameServer> serversToUpdate = new ArrayList<>();
+				serversToUpdate.addAll(servers);
+				for (GameServer server:serversToUpdate) {
+					logger.fine("activeServer="+activeServer);
+					logger.fine("server="+server);
+					if (activeServer==null || !server.equals(activeServer)) {
+						logger.fine("updating a server with "+changes.size());
+						server.addObjectChanges(changes);
+					}
+				}
+
+				if (activeServer!=null && fireChange) {
+					shouldFire = true;
 				}
 			}
-			
-			if (activeServer!=null && fireChange) {
-				// only fire this event if the changes came from another server
-				fireHostModified();
-			}
+		}
+		// GameHost lock is released — fireHostModified/updateGame may be slow but will
+		// no longer block other GameServer threads from servicing REQUEST_IDLE.
+		if (shouldFire) {
+			fireHostModified();
 		}
 		return true;
 	}

--- a/game/utility/game_server/source/com/robin/game/server/GameNet.java
+++ b/game/utility/game_server/source/com/robin/game/server/GameNet.java
@@ -6,36 +6,31 @@ import java.util.ArrayList;
 
 public abstract class GameNet extends Thread {
 	
-	// BUG: DEFAULT_TIMEOUT_MS = 10000 (10 seconds) is far too short for gameplay.
+	// Root cause of the End Battle combat freeze: DEFAULT_TIMEOUT_MS = 10000 (10 seconds).
 	//
-	// SO_TIMEOUT is set on every client socket (GameClient.java, GameConnector.java) and fires
-	// when a blocking read() call does not receive data within the timeout period. During normal
-	// play the GameClient thread polls continuously via REQUEST_IDLE, so the socket rarely idles
-	// long enough to trigger it. However, modal combat dialogs (e.g. the End Battle yes/no dialog
-	// in CombatFrame) can block the client long enough for the timeout to fire:
+	// SO_TIMEOUT is set on every server-side socket (via GameConnector) and every client-side
+	// socket (via GameClient). It fires when a blocking read() call does not receive data within
+	// the timeout period. During normal play the GameClient thread polls continuously via
+	// REQUEST_IDLE, so the socket rarely idles long enough to trigger it. However, when
+	// handleDirectInfo() showed a modal combat dialog directly on the GameClient thread, it
+	// blocked that thread and caused the server-side timeout to fire:
 	//
-	//   1. One combatant clicks End — the server broadcasts a vote request to all participants.
-	//   2. Each client shows the End Battle dialog (blocking the EDT for that player).
-	//   3. A player takes more than 10 seconds to respond.
-	//   4. The socket read times out → SocketTimeoutException → GameClient.run() catches it
-	//      as an unexpected disconnect → the server calls removeServer() → fireServerLost().
-	//   5. The remaining clients receive "Broken pipe" when they try to write to the now-closed
-	//      socket, or the server broadcasts a game-over notice.
-	//   6. The End Battle vote count never reaches quorum → all combat windows show "Observing"
-	//      with no End/Next buttons, and the combat is permanently frozen.
+	//   1. One combatant clicks End — the server broadcasts a QUERY_YN to all participants.
+	//   2. Each client's GameClient thread enters handleDirectInfo() and (originally) called
+	//      JOptionPane.showConfirmDialog() there, blocking that thread.
+	//   3. Blocked GameClient thread sends no REQUEST_IDLE messages to the server.
+	//   4. The server-side SO_TIMEOUT fires (set by GameConnector) → SocketTimeoutException
+	//      in GameServer.processNextRequest() → GameServer's run() loop terminates →
+	//      host.removeServer() → fireServerLost() → "Game over!!" broadcast.
+	//   5. Remaining clients receive "Broken pipe" when they try to write their responses.
+	//   6. The End Battle vote never reaches quorum → all combat windows show "Observing"
+	//      with no End/Next buttons, and combat is permanently frozen.
 	//
-	// Fix options (to be implemented):
-	//   (A) Raise DEFAULT_TIMEOUT_MS to a value that is safely longer than any realistic player
-	//       think time (e.g. 5 minutes = 300_000 ms). Simple and low-risk.
-	//   (B) Set SO_TIMEOUT to 0 (no timeout) for the game socket and rely on the application-
-	//       level disconnect detection instead. Requires companion keepalive or heartbeat logic
-	//       so the server can still detect genuinely dead clients.
-	//   (C) Have the client send a lightweight keepalive message while a modal dialog is open,
-	//       resetting the idle clock on the server side.
-	//
-	// Option A is the lowest-risk change. Option B or C would be cleaner long-term but require
-	// more rework, especially if the client-reconnect feature is also being integrated.
-	public static int DEFAULT_TIMEOUT_MS = 10000; // TODO: raise this — 10 s is too short for gameplay dialogs
+	// Fix (applied in RealmGameHandler.handleDirectInfo, QUERY_YN branch): dispatch the dialog
+	// to the EDT via SwingUtilities.invokeLater(). handleDirectInfo() returns immediately,
+	// the GameClient thread keeps polling normally, and the server timeout is never hit
+	// regardless of how long the player takes. DEFAULT_TIMEOUT_MS is left unchanged.
+	public static int DEFAULT_TIMEOUT_MS = 10000;
 	
 	protected Socket connection;
 	protected ObjectOutputStream out = null;

--- a/game/utility/game_server/source/com/robin/game/server/GameNet.java
+++ b/game/utility/game_server/source/com/robin/game/server/GameNet.java
@@ -6,7 +6,36 @@ import java.util.ArrayList;
 
 public abstract class GameNet extends Thread {
 	
-	public static int DEFAULT_TIMEOUT_MS = 10000; // a 10 second timeout should be good enough
+	// BUG: DEFAULT_TIMEOUT_MS = 10000 (10 seconds) is far too short for gameplay.
+	//
+	// SO_TIMEOUT is set on every client socket (GameClient.java, GameConnector.java) and fires
+	// when a blocking read() call does not receive data within the timeout period. During normal
+	// play the GameClient thread polls continuously via REQUEST_IDLE, so the socket rarely idles
+	// long enough to trigger it. However, modal combat dialogs (e.g. the End Battle yes/no dialog
+	// in CombatFrame) can block the client long enough for the timeout to fire:
+	//
+	//   1. One combatant clicks End — the server broadcasts a vote request to all participants.
+	//   2. Each client shows the End Battle dialog (blocking the EDT for that player).
+	//   3. A player takes more than 10 seconds to respond.
+	//   4. The socket read times out → SocketTimeoutException → GameClient.run() catches it
+	//      as an unexpected disconnect → the server calls removeServer() → fireServerLost().
+	//   5. The remaining clients receive "Broken pipe" when they try to write to the now-closed
+	//      socket, or the server broadcasts a game-over notice.
+	//   6. The End Battle vote count never reaches quorum → all combat windows show "Observing"
+	//      with no End/Next buttons, and the combat is permanently frozen.
+	//
+	// Fix options (to be implemented):
+	//   (A) Raise DEFAULT_TIMEOUT_MS to a value that is safely longer than any realistic player
+	//       think time (e.g. 5 minutes = 300_000 ms). Simple and low-risk.
+	//   (B) Set SO_TIMEOUT to 0 (no timeout) for the game socket and rely on the application-
+	//       level disconnect detection instead. Requires companion keepalive or heartbeat logic
+	//       so the server can still detect genuinely dead clients.
+	//   (C) Have the client send a lightweight keepalive message while a modal dialog is open,
+	//       resetting the idle clock on the server side.
+	//
+	// Option A is the lowest-risk change. Option B or C would be cleaner long-term but require
+	// more rework, especially if the client-reconnect feature is also being integrated.
+	public static int DEFAULT_TIMEOUT_MS = 10000; // TODO: raise this — 10 s is too short for gameplay dialogs
 	
 	protected Socket connection;
 	protected ObjectOutputStream out = null;

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
@@ -1023,16 +1023,31 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 			}
 		}
 		else if (RealmDirectInfoHolder.QUERY_YN.equals(command)) {
+			// THREADING: this branch runs on the GameClient thread (via receiveInfoDirect ->
+			// handleDirectInfo). The original code called JOptionPane.showConfirmDialog()
+			// directly here, which blocked the GameClient thread for as long as the user took
+			// to respond. While blocked, no REQUEST_IDLE messages were sent to the server.
+			// After 10 s the server-side SO_TIMEOUT fired, the GameServer for this client
+			// called removeServer() -> "The server was shut down. Game over!!" was broadcast
+			// to everyone, and the End Combat flow was permanently broken.
+			//
+			// Fix: dispatch the dialog to the EDT via invokeLater so handleDirectInfo()
+			// returns immediately, unblocking the GameClient thread. The GameClient continues
+			// polling normally while the user thinks. When the user clicks Yes/No the EDT
+			// callback sends the response via sendInfoDirect(), which queues it on the
+			// GameClient's requestQueue for delivery on the next loop iteration.
 			String string = info.getString();
 			int colon = string.indexOf(":");
-			long id = Long.valueOf(string.substring(0, colon)).longValue();
-			string = string.substring(colon + 1);
-			int ret = JOptionPane.showConfirmDialog(CombatFrame.getSingleton(), string, "End Combat?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
-
-			RealmDirectInfoHolder infoResponse = new RealmDirectInfoHolder(getClient().getGameData(), getClient().getClientName());
-			infoResponse.setCommand(RealmDirectInfoHolder.QUERY_RESPONSE);
-			infoResponse.setString(id + ":" + (ret == JOptionPane.YES_OPTION ? RealmDirectInfoHolder.QUERY_RESPONSE_YES : RealmDirectInfoHolder.QUERY_RESPONSE_NO));
-			getClient().sendInfoDirect(info.getPlayerName(), infoResponse.getInfo());
+			final long id = Long.valueOf(string.substring(0, colon)).longValue();
+			final String message = string.substring(colon + 1);
+			final String playerName = info.getPlayerName();
+			SwingUtilities.invokeLater(() -> {
+				int ret = JOptionPane.showConfirmDialog(CombatFrame.getSingleton(), message, "End Combat?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+				RealmDirectInfoHolder infoResponse = new RealmDirectInfoHolder(getClient().getGameData(), getClient().getClientName());
+				infoResponse.setCommand(RealmDirectInfoHolder.QUERY_RESPONSE);
+				infoResponse.setString(id + ":" + (ret == JOptionPane.YES_OPTION ? RealmDirectInfoHolder.QUERY_RESPONSE_YES : RealmDirectInfoHolder.QUERY_RESPONSE_NO));
+				getClient().sendInfoDirect(playerName, infoResponse.getInfo());
+			});
 		}
 		else if (RealmDirectInfoHolder.POPUP_MESSAGE.equals(command)) {
 			RealmUtility.popupMessage(CombatFrame.getSingleton(), info);


### PR DESCRIPTION
## Problem

When a player takes more than 10 seconds to respond to the End Combat yes/no dialog, the game freezes permanently. Observed symptom: all combat windows switch to "Observing" with no End/Next buttons, no recovery path.

**Root cause:** `handleDirectInfo()` handles `QUERY_YN` on the `GameClient` thread. The original code called `JOptionPane.showConfirmDialog()` directly there, blocking that thread for the duration of the player's response. While it was blocked, no `REQUEST_IDLE` messages reached the server. After 10 seconds the server's `SO_TIMEOUT` fired, the server called `removeServer()` → `fireServerLost()`, and all remaining clients got "Broken pipe" `SocketException` when they tried to send their vote responses. The End Combat vote never reached quorum.

Stack trace from error log:
```
java.net.SocketException: Broken pipe
    at com.robin.game.server.GameNet.flush(GameNet.java:28)
    at com.robin.game.server.GameClient.send(GameClient.java:212)
    at com.robin.game.server.GameClient.doRequest(GameClient.java:414)
    at com.robin.game.server.GameClient.run(GameClient.java:377)
```

## Fixes

### Primary fix — `RealmGameHandler.handleDirectInfo()` (QUERY_YN branch)

Move `JOptionPane.showConfirmDialog()` to the EDT via `SwingUtilities.invokeLater()`. `handleDirectInfo()` returns immediately, the `GameClient` thread continues polling, and the server's timeout is never hit regardless of how long the player takes.

### Secondary fix — `GameHost.applyChanges()`

Refactored from a `synchronized` method to a block-scoped lock that releases before calling `fireHostModified()`. Previously, `fireHostModified()` → `updateGame()` ran inside the lock and could take several seconds (game state machine + autosave). During that time any `GameServer` thread calling `getMasterToGameChanges()` blocked on the same lock, putting pressure on the `SO_TIMEOUT` budget. This fix is defensive — it reduces lock contention even if the primary fix above is not present.

## Testing

1. Start a server and 2+ clients; start combat between characters.
2. When one player clicks End Combat and the yes/no dialog appears for all participants, wait at least 20–30 seconds before responding on one client.
3. Verify all clients can still respond, the vote reaches quorum, and combat resolves normally.
4. Confirm no "Broken pipe" `SocketException` entries appear in the `RealmSpeakError*.log` file.

This was verified with a 20+ minute wait — all clients responded successfully and combat resolved.