### PR TITLE
Fix: familiar/phantasm frozen when blocking character with color chits shares clearing

### DIFF
--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -496,7 +496,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 		boolean recordingActions = character.isDoRecord() && actionPanel.getActionControlManager().getCurrentlyRecordingAction() == null;
 		boolean canTrade = getCharacter().isCharacter() || getCharacter().isHiredLeader() || getCharacter().isControlledMonster();
 		viewChitsButton.setVisible(character.isHidden() && hostPrefs.hasPref(Constants.OPT_QUIET_MONSTERS));
-		if (character.isBlocking()) {
+		if (!character.isMinion() && character.isBlocking()) {
 			blockButton.setIcon(IconFactory.findIcon("images/interface/blockon.gif"));
 			blockButton.setToolTipText("Block/Reactions ON");
 			blockButton.setSelected(true);
@@ -1679,7 +1679,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 		blockButton = new JToggleButton(IconFactory.findIcon("images/interface/blockoff.gif"),false);
 		blockButton.setToolTipText("Block/Reactions OFF");
 		ComponentTools.lockComponentSize(blockButton,39,39);
-		if (character.isBlocking()) {
+		if (!character.isMinion() && character.isBlocking()) {
 			blockButton.setIcon(IconFactory.findIcon("images/interface/blockon.gif"));
 			blockButton.setToolTipText("Block/Reactions ON");
 			blockButton.setSelected(true);

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -367,9 +367,9 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 			phaseName = "MIDNIGHT";
 		}
 		setTitle(character.getCharacterName() + " - Month " + character.getCurrentMonth() + ", Day " + character.getCurrentDay()+" - "+phaseName);
-		dailyCombatCheckbox.setSelected(character.getWantsCombat());
-		dayEndRearrangmentCheckbox.setSelected(character.getWantsDayEndTrades());
-		keepBlockingCheckbox.setSelected(character.keepsBlocking());
+		dailyCombatCheckbox.setSelected(!character.isMinion() && character.getWantsCombat());
+		dayEndRearrangmentCheckbox.setSelected(!character.isMinion() && character.getWantsDayEndTrades());
+		keepBlockingCheckbox.setSelected(!character.isMinion() && character.keepsBlocking());
 		
 		// Update mountain move icon (might change with seasons/weather)
 		mountainMoveIcon.setCost(getCharacter().getMountainMoveCost()+(character.addsOneToMoveExceptCaves()?1:0));
@@ -1172,7 +1172,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 			});
 			showCharCardButton.setEnabled(character.isCharacter());
 			sideControls.add(showCharCardButton);
-			dailyCombatCheckbox = new JCheckBox("Daily Combat",character.getWantsCombat());
+			dailyCombatCheckbox = new JCheckBox("Daily Combat",!character.isMinion() && character.getWantsCombat());
 			dailyCombatCheckbox.addActionListener(new ActionListener() {
 				public void actionPerformed(ActionEvent ev) {
 					character.setWantsCombat(dailyCombatCheckbox.isSelected());

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
@@ -807,12 +807,14 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 			ArrayList<GameObject> allChars = RealmUtility.getLivingCharacters(client.getGameData());
 			for (int i = 0; i < allChars.size(); i++) {
 				CharacterWrapper cw1 = new CharacterWrapper(allChars.get(i));
+				if (cw1.isMinion()) continue;
 				cw1.setBlocking(true);
 				cw1.setKeepBlocking(true);
 				cw1.setWantsCombat(true);
 				cw1.setWantsDayEndTrades(true);
 				for (int j = i + 1; j < allChars.size(); j++) {
 					CharacterWrapper cw2 = new CharacterWrapper(allChars.get(j));
+					if (cw2.isMinion()) continue;
 					cw1.setEnemyCharacter(allChars.get(j), true);
 					cw2.setEnemyCharacter(allChars.get(i), true);
 				}
@@ -1726,7 +1728,7 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 					// No need to send again - it'll get sent quickly enough
 
 					// Done
-					if (hostPrefs.hasPref(Constants.OPT_SUSPICIOUS_CHARACTERS)) {
+					if (hostPrefs.hasPref(Constants.OPT_SUSPICIOUS_CHARACTERS) && !character.isMinion()) {
 						character.setBlocking(true);
 						character.setKeepBlocking(true);
 						character.setWantsCombat(true);
@@ -1735,6 +1737,7 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 						for (GameObject existing : livingCharacters) {
 							if (!existing.equals(character.getGameObject())) {
 								CharacterWrapper existingWrapper = new CharacterWrapper(existing);
+								if (existingWrapper.isMinion()) continue;
 								character.setEnemyCharacter(existing, true);
 								existingWrapper.setEnemyCharacter(character.getGameObject(), true);
 							}

--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/wrapper/CharacterWrapper.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/wrapper/CharacterWrapper.java
@@ -8591,7 +8591,12 @@ public class CharacterWrapper extends GameObjectWrapper {
 					CharacterWrapper otherCharacter = new CharacterWrapper(rc.getGameObject());
 					if (otherCharacter.isSleep() && hostPrefs.hasPref(Constants.OPT_NO_COLOR_CHIT_FOR_SLEEPING_CHARACTERS)) continue;
 					if (otherCharacter.isBlocking() && otherCharacter.getColorMagicChits().size()>0 && !rc.getGameObject().hasThisAttribute(Constants.MAGIC_PROTECTION_EXTENDED)) {
-						if ((phaseBeginnig && !otherCharacter.hasColorChitInterruptPhaseBeginningDecision(getGameObject())) || (phaseEnd && !otherCharacter.hasColorChitInterruptPhaseEndDecision(getGameObject()))) {
+						// Only count a blocker as an interrupter if checkForColorChitInterruptionState actually
+						// determined they need to play (i.e., the phasing character is a valid interrupt target).
+						// Familiars are not PlayerControlledLeaders, so blocking characters correctly set
+						// NeedsPlayColorChit...=false for them; without this guard those blockers still appeared
+						// as interrupters, permanently freezing the familiar's action processing.
+						if ((phaseBeginnig && otherCharacter.getNeedsPlayColorChitInterruptPhaseBeginningDecision() && !otherCharacter.hasColorChitInterruptPhaseBeginningDecision(getGameObject())) || (phaseEnd && otherCharacter.getNeedsPlayColorChitInterruptPhaseEndDecision() && !otherCharacter.hasColorChitInterruptPhaseEndDecision(getGameObject()))) {
 							list.add(rc);
 						}
 					}


### PR DESCRIPTION
## Summary

Two bugs affecting familiars and phantasms (minions) when sharing a clearing
with blocking characters:

1. **Familiar/phantasm freeze** — with \`OPT_PHASE_BEGIN_PLAYING_COLOR_CHIT\` enabled,
   a phasing minion is permanently frozen: Play Next has no visible effect.
2. **SUSPICIOUS CHARACTERS init bleeds onto minions** — Blocking, Daily Combat,
   Day End Trades, and enemy relationships were incorrectly applied to familiars
   and phantasms at game start and character join.

## Root Cause (freeze)

\`checkForColorChitInterruptionState\` (called on the blocker) correctly sets
\`NeedsPlayColorChit…=false\` when the phasing character is a minion, because
minions are not \`isPlayerControlledLeader()\`. But \`getPossibleColorChitInterrupters\`
(called on the phasing minion) did not check that flag — it returned any blocking
character with color chits as an interrupter. \`ActionRow.process()\` then returned
without setting \`completed=true\`, leaving the action permanently pending.

## Fixes

**\`CharacterWrapper.getPossibleColorChitInterrupters\`:** Add
\`getNeedsPlayColorChitInterrupt…Decision()\` to the filter so the two methods
stay in sync. A blocker that has nothing to interrupt (flag=false) no longer
appears as an interrupter. Covers both phase-BEGIN and phase-END paths, and
both \`isFamiliar()\` and \`isPhantasm()\`.

**\`RealmGameHandler\` SUSPICIOUS CHARACTERS loops:** Skip \`isMinion()\` entries
in \`startGame()\` and \`createNewCharacter()\` — both the outer reaction-flag
setters and the inner enemy-relationship loop.

**\`CharacterFrame\` checkboxes:** Force Daily Combat, Day End Trades, and
DayStart Reactions to show unchecked for minions in both initial construction
and \`updateCharacter()\`, regardless of stale data in the game object.

## Other mechanisms: confirmed safe

| Mechanism | Guard |
|---|---|
| \`willBeBlocked\` | \`!character.isMinion()\` in \`RealmUtility\` |
| \`checkForBlockingState\` | \`!isMinion()\` internal guard |
| \`getPossibleBlockees\` | only considers \`isPlayerControlledLeader()\` targets |
| \`playColorChitNowButton\` / \`blockNowButton\` | flags can never be set true on minions |

🤖 Generated with [Claude Code](https://claude.com/claude-code)