### PR TITLE
Respect MAP_CENTER_ON_CHARACTER option at turn start and table selection

### DIFF
--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
@@ -166,7 +166,9 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 					CharacterFrame frame = characterFrames.get(id);
 					if (frame != null) {
 						frame.toFront();
-						frame.centerOnToken();
+						if (isOption(RealmSpeakOptions.MAP_CENTER_ON_CHARACTER)) {
+							frame.centerOnToken();
+						}
 						characterFrameOrder.remove(id);
 						characterFrameOrder.add(0, id);
 					}
@@ -2278,7 +2280,9 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 				}
 				frame.showActionPanel();
 				frame.toFront();
-				frame.centerOnToken();
+				if (isOption(RealmSpeakOptions.MAP_CENTER_ON_CHARACTER)) {
+					frame.centerOnToken();
+				}
 				String id = character.getGameObject().getStringId();
 				characterFrameOrder.remove(id);
 				characterFrameOrder.add(0, id);


### PR DESCRIPTION
## Summary
- `showNextRecordFrame()` called `centerOnToken()` unconditionally, ignoring the "Map centering on Character" client option — so the map always centered when a character's turn started regardless of the setting
- The character table selection listener had the same missing guard — and since `showNextRecordFrame()` triggers a selection event internally, both sites needed the fix
- When the option is unchecked, nothing now causes automatic map centering

## Test plan
- [ ] Uncheck "Map centering on Character" in client options; verify map does not center when a character's turn starts
- [ ] Uncheck option; verify map does not center when clicking a character row in the character table
- [ ] Check option; verify both behaviors still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)