### PR TITLE
Fix native drinks dialog firing multiple times per evening

### DIFF
--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/BattlesWrapper.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/BattlesWrapper.java
@@ -213,6 +213,7 @@ public class BattlesWrapper extends GameObjectWrapper {
 		for (RealmComponent owner : model.getAllOwningCharacters()) {
 			CharacterWrapper character = new CharacterWrapper(owner.getGameObject());
 			CombatWrapper.clearAllCombatInfo(character.getGameObject());
+			character.getGameObject().removeThisAttribute(Constants.COMBAT_PREBATTLE_DONE);
 			character.clearCombat();
 			character.decrementCombatCount();
 		}

--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
@@ -4763,7 +4763,10 @@ public class CombatFrame extends JFrame {
 			logger.finer("handling prebattle");
 			ArrayList<CharacterWrapper> list = lists.getList(firstState);
 			CharacterWrapper character = list.iterator().next();
-			processBattlingNatives(frame,character,data);
+			if (!character.getGameObject().hasThisAttribute(Constants.COMBAT_PREBATTLE_DONE)) {
+				character.getGameObject().setThisAttribute(Constants.COMBAT_PREBATTLE_DONE);
+				processBattlingNatives(frame,character,data);
+			}
 			character.setCombatStatus(Constants.COMBAT_WAIT+Constants.COMBAT_LURE);
 			listener.actionPerformed(new ActionEvent(parent,0,"")); // does the submit in RealmSpeak
 		}

--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/utility/Constants.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/utility/Constants.java
@@ -251,6 +251,7 @@ public class Constants {
 	public static final String FORESIGHT_USED = "foresight_used";
 	public static final String STEAL_ATTEMPTS = "stealing_attempts";
 	public static final String DRINKS_BOUGHT = "drinks_bought";
+	public static final String COMBAT_PREBATTLE_DONE = "_prebattle_done_";
 	public static final String FORESIGHT_SAVED_STATS = "foresight_saved_stats";
 	public static final String FORESIGHT_SAVED_STATS_WISHED_STRENGTH = "wished_strength_";
 	public static final String SEAFARING = "seafaring";


### PR DESCRIPTION
## Summary

- `CombatFrame.doDisplay()` re-enters `COMBAT_PREBATTLE` state each combat cycle (once per Lure phase), causing `processBattlingNatives()` — and therefore the Buy Drinks dialog — to fire for every unhired native group on every combat round, not just once at evening start.
- Add a `COMBAT_PREBATTLE_DONE` flag on the character to guard `processBattlingNatives()` so it runs at most once per combat session.
- Clear the flag in `BattlesWrapper.clearBattleInfo()` when the combat session ends, so the evening check works correctly in subsequent combats.

## Files changed

- `Constants.java` — new constant `COMBAT_PREBATTLE_DONE = "_prebattle_done_"`
- `CombatFrame.java` — guard wrapping the `processBattlingNatives()` call
- `BattlesWrapper.java` — clear flag in `clearBattleInfo()`

## Test plan

- [ ] Enter a clearing with one or more unhired native groups and end the day; confirm each group shows exactly one Buy Drinks dialog at evening, regardless of how many combat rounds follow.
- [ ] Verify the dialog appears again correctly in a subsequent combat session (flag cleared properly).
- [ ] Confirm HIRE and TRADE-BUY actions still show their own per-action drinks dialog as before (unrelated code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)