### PR TITLE
Toggle buttons for character bottom tabs, Show Card, and combat log

### DIFF
--- a/general/utility/general_swing/source/com/robin/general/swing/FrameManager.java
+++ b/general/utility/general_swing/source/com/robin/general/swing/FrameManager.java
@@ -53,6 +53,9 @@ public class FrameManager {
 		}
 		return false;
 	}
+	public boolean hasFrame(String frameKey) {
+		return frameHash.containsKey(frameKey);
+	}
 	public void disposeFrame(String frameKey) {
 		ManagedFrame cached = frameHash.get(frameKey);
 		if (cached!=null) {

--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
@@ -86,7 +86,7 @@ public class CombatFrame extends JFrame {
 	private JButton combatSummaryButton;
 	private JToggleButton lockNextButton;
 	private JButton undoButton;
-	private JButton textButton;
+	private JToggleButton textButton;
 	private FlashingButton endButton; // if combat is not necessary (ie., all characters are hidden)
 	private FlashingButton nextButton;
 	
@@ -1185,6 +1185,7 @@ public class CombatFrame extends JFrame {
 				list.add(getSuggestButton());
 			}
 			list.add(getShowPanel());
+			list.add(gameControls);
 		}
 		else {
 			instructionLabel = new JLabel("Observing");
@@ -1295,8 +1296,7 @@ public class CombatFrame extends JFrame {
 		});
 		bottomPanel.add(combatSummaryButton,"Center");
 		gameControls = new JPanel(new GridLayout(2,2));
-		bottomPanel.add(gameControls,"South");
-		
+
 		undoButton = new JButton("Reset");
 		undoButton.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent ev) {
@@ -1310,13 +1310,27 @@ public class CombatFrame extends JFrame {
 			}
 		});
 		gameControls.add(undoButton);
-		textButton = new JButton("Details");
+		textButton = new JToggleButton("Details");
+		textButton.setSelected(RealmLogWindow.getSingleton().isVisible());
 		textButton.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent ev) {
 				RealmLogWindow log = RealmLogWindow.getSingleton();
-				log.setVisible(true);
-				log.toFront();
-				log.scrollToEnd();
+				if (textButton.isSelected()) {
+					log.setVisible(true);
+					log.toFront();
+					log.scrollToEnd();
+				}
+				else {
+					log.setVisible(false);
+				}
+			}
+		});
+		RealmLogWindow.getSingleton().addComponentListener(new ComponentAdapter() {
+			public void componentShown(ComponentEvent ev) {
+				textButton.setSelected(true);
+			}
+			public void componentHidden(ComponentEvent ev) {
+				textButton.setSelected(false);
 			}
 		});
 		gameControls.add(textButton);
@@ -1341,6 +1355,7 @@ public class CombatFrame extends JFrame {
 		nextButton.setFont(INSTRUCTION_FONT);
 		gameControls.add(nextButton);
 		ComponentTools.lockComponentSize(gameControls,180,80);
+		gameControls.setBorder(BorderFactory.createLineBorder(Color.yellow,6));
 		sidePanel.add(bottomPanel,"South");
 		
 		controlPanel = Box.createVerticalBox();

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1115,6 +1115,26 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 		}
 		tabs.addTab(null, ImageCache.getIcon("tab/chat"), getChatPanel(),"Chat");
 
+		// JTabbedPane selects on mousePressed (before mouseClicked fires), so we can't use
+		// "clicked == selectedIndex" in mouseClicked — it's always true by then.
+		// Instead, let the ChangeListener mark when a click actually changed the tab;
+		// absence of that mark means the user re-clicked the already-selected tab → toggle home.
+		boolean[] tabChangedByThisPress = {false};
+		tabs.addChangeListener(e -> tabChangedByThisPress[0] = true);
+		tabs.addMouseListener(new MouseAdapter() {
+			public void mouseClicked(MouseEvent e) {
+				int clicked = tabs.indexAtLocation(e.getX(), e.getY());
+				if (clicked >= 0 && !tabChangedByThisPress[0]) {
+					int homeIdx = 0;
+					for (int i = 0; i < tabs.getTabCount(); i++) {
+						if (RealmTurnPanel.TAB_NAME.equals(tabs.getToolTipTextAt(i))) { homeIdx = i; break; }
+					}
+					tabs.setSelectedIndex(homeIdx);
+				}
+				tabChangedByThisPress[0] = false;
+			}
+		});
+
 		layoutPanel.add(tabs, "Center");
 
 		//		updateCharacter(); // no need to do this here
@@ -2299,6 +2319,10 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 	}
 
 	private void showCharCard() {
+		if (FrameManager.getFrameManager().hasFrame(FrameManager.DEFAULT_FRAME_KEY)) {
+			FrameManager.getFrameManager().disposeFrame(FrameManager.DEFAULT_FRAME_KEY);
+			return;
+		}
 		CharacterSpyPanel panel = new CharacterSpyPanel(gameHandler, character);
 		FrameManager.showDefaultManagedFrame(gameHandler.getMainFrame(), panel, character.getGameObject().getName() + " Spy", null, false);
 	}

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1115,14 +1115,20 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 		}
 		tabs.addTab(null, ImageCache.getIcon("tab/chat"), getChatPanel(),"Chat");
 
-		// JTabbedPane selects on mousePressed (before mouseClicked fires), so we can't use
-		// "clicked == selectedIndex" in mouseClicked — it's always true by then.
-		// Instead, let the ChangeListener mark when a click actually changed the tab;
-		// absence of that mark means the user re-clicked the already-selected tab → toggle home.
+		// JTabbedPane's own mousePressed listener (installed by the UI delegate, registered
+		// before ours) changes the selection synchronously, before our listener runs — so by
+		// the time any of our listeners fire, "clicked == selectedIndex" is always true and
+		// useless for detecting a re-click. Instead, the ChangeListener marks when a press
+		// actually changed the tab; absence of that mark means the user pressed the
+		// already-selected tab → toggle home.
+		// Use mousePressed rather than mouseClicked: AWT only synthesizes mouseClicked when
+		// press and release land at (nearly) the same pixel, which trackpads routinely miss
+		// even on an intended single click — causing the toggle to silently do nothing and
+		// requiring several repeated clicks before one happens to land cleanly.
 		boolean[] tabChangedByThisPress = {false};
 		tabs.addChangeListener(e -> tabChangedByThisPress[0] = true);
 		tabs.addMouseListener(new MouseAdapter() {
-			public void mouseClicked(MouseEvent e) {
+			public void mousePressed(MouseEvent e) {
 				int clicked = tabs.indexAtLocation(e.getX(), e.getY());
 				if (clicked >= 0 && !tabChangedByThisPress[0]) {
 					int homeIdx = 0;

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
@@ -1012,7 +1012,7 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 				// If a spell is being applied through direct info, then make sure the combat frame reflects the change!!
 				resetCombatFrame();
 				if (teleported) {
-					// Character left the combat clearing — submit to unblock server-side combat state machine.
+					// Character left the combat clearing â€” submit to unblock server-side combat state machine.
 					submitChangesWithTimeout();
 				}
 			});


### PR DESCRIPTION
## Summary
- Bottom tabs in the character frame now toggle: clicking a non-home tab switches to it; clicking it again (or clicking the home tab) returns to the Your Turn / Record Actions tab.
- The Show Card button now toggles the character spy card open/closed instead of only opening it.
- Moved the Reset/Details/End/Next combat button group to just above the combat sheets table, with a yellow border matching the "Round N" header color.
- The Details button is now a toggle for the combat log window, kept in sync via a `ComponentListener` so external opens/closes don't desync the button state.
- Fixed: the tab toggle used `mouseClicked`, which AWT only synthesizes when press and release land at nearly the same pixel — trackpad drift routinely suppressed it, requiring several repeated clicks. Moved the logic to `mousePressed`, which always fires.
- Also fixes an `0x97` byte (mangled em-dash) in a `RealmGameHandler.java` comment that fails javac's UTF-8 source encoding.

## Test plan
- [x] Build and launch; click each bottom tab in a character frame — confirm it shows the tab, and a second click (or a click on the home tab) returns to Your Turn / Record Actions.
- [x] Click Show Card — confirm it opens; click again — confirm it closes.
- [x] Enter combat — confirm Reset/Details/End/Next buttons appear above the combat sheets table with a yellow border.
- [x] Click Details — confirm the log window shows/hides in sync with the button's toggle state.