### PR TITLE
Fix NPE in MagicShieldEffect.unapply when shield object has no parent

### DIFF
--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/effect/MagicShieldEffect.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/effect/MagicShieldEffect.java
@@ -46,7 +46,9 @@ public class MagicShieldEffect implements ISpellEffect {
 					.getGameObject()
 					.getGameData()
 					.getGameObject(Long.valueOf(context.Spell.getGameObject().getThisAttribute(Constants.MAGIC_SHIELD_ID)));
-			magicShield.getHeldBy().remove(magicShield);
+			if (magicShield != null && magicShield.getHeldBy() != null) {
+				magicShield.getHeldBy().remove(magicShield);
+			}
 			context.Spell.getGameObject().removeThisAttribute(Constants.MAGIC_SHIELD_ID);
 		}
 	}


### PR DESCRIPTION
When combat ends with no action (e.g. 2 rounds of inactivity), the magic shield effect object can become detached from its parent container before expireCombatSpells() runs at midnight. The subsequent getHeldBy().remove() call threw a NullPointerException. Guard with null checks on both the retrieved object and its parent.

Extracted from local-feature/interphase-dialogs.

In some of the cleanup I was doing, I found this fix that does not seem to be in master.  Is it something that should go in, or maybe it was no longer needed in some work you did on the magic shield?  Just checking to be sure.