### PR TITLE
Fix offroad travel data and Backspace undo

### DIFF
--- a/data/MagicRealmData.xml
+++ b/data/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterActionControlManager.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterActionControlManager.java
@@ -506,9 +506,13 @@ public class CharacterActionControlManager {
 		
 		ArrayList<String> actions = new ArrayList<>();
 		Collection<String> c = getCharacter().getCurrentActions();
+		String removed = null;
 		if (c!=null && !c.isEmpty()) {
 			actions.addAll(c);
-			String removed = actions.remove(actions.size()-1);
+			removed = actions.remove(actions.size()-1);
+			if (removed.startsWith(DayAction.OFFROAD_TRAVEL_ACTION.getCode())) {
+				actions.remove(actions.size()-1);
+			}
 			if (removed.startsWith(DayAction.MOVE_ACTION.getCode()) || removed.startsWith(DayAction.FLY_ACTION.getCode())) {
 				// deleting a move, so delete a clearing plot
 				getCharacter().chompClearingPlot();
@@ -538,6 +542,9 @@ public class CharacterActionControlManager {
 		if (c!=null && !c.isEmpty()) {
 			actionTypeCodes.addAll(c);
 			actionTypeCodes.remove(actionTypeCodes.size()-1);
+			if (removed != null &&  removed.startsWith(DayAction.OFFROAD_TRAVEL_ACTION.getCode())) {
+				actionTypeCodes.remove(actionTypeCodes.size()-1);
+			}
 		}
 		getCharacter().setCurrentActionTypeCodes(actionTypeCodes);
 		

--- a/magic_realm/utility/components/resources/data/MagicRealmData.xml
+++ b/magic_realm/utility/components/resources/data/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />

--- a/products/gameData/MagicRealmData.xml
+++ b/products/gameData/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />


### PR DESCRIPTION
## Summary

- Fill in missing `offroad_travel_side_1`/`_2` attribute lists for two tiles that master left as empty `offroad_travel_sides=""` stubs (all three `MagicRealmData.xml` copies: `data/`, `magic_realm/utility/components/resources/data/`, and `products/gameData/`).
- Fix `CharacterActionControlManager.doBackspace()`: an offroad travel action records two action-code entries (the offroad code plus the resulting move), but Backspace only removed one, leaving a stray entry behind. Now removes both when the offroad code is detected.

## Test plan

- [x] `ant clean-build-RealmSpeakFull` succeeds
- [ ] Reviewer: verify offroad travel is selectable/valid on the two previously-empty tiles, and that Backspace after an offroad move cleanly removes the whole action with no leftover phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)