### PR TITLE
Click character token to center map, with draggable Default View controls

### DIFF
--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1183,7 +1183,10 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 			charLabel.setIconTextGap(10);
 			charLabel.addMouseListener(new MouseAdapter() {
 				public void mousePressed(MouseEvent ev) {
-					tokenClicked();
+					Icon icon = charLabel.getIcon();
+					if (icon != null && ev.getX() <= charLabel.getInsets().left + icon.getIconWidth()) {
+						tokenClicked();
+					}
 				}
 			});
 			tokenPanel.add(charLabel, "West");

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1817,10 +1817,13 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 	}
 
 	private void tokenClicked() {
-		toggleCenterOnToken();
 		if (DebugUtility.isCheat()) {
-			// If CHEAT is on, then clicking the token will allow you to cheat
+			// If CHEAT is on, clicking the token opens the cheat prompt instead of toggling the
+			// map view — the two features share this click and would otherwise fight over it
+			// (every cheat click also toggling/un-toggling the centered view underneath the dialog).
 			cheat();
+		} else {
+			toggleCenterOnToken();
 		}
 	}
 

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1145,7 +1145,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 	}
 
 	public void centerOnToken() {
-		if (gameHandler.getGame().getGameStarted() && gameHandler.isOption(RealmSpeakOptions.MAP_CENTER_ON_CHARACTER)) {
+		if (gameHandler.getGame().getGameStarted()) {
 			gameHandler.getInspector().getMap().centerOn(character.getCurrentLocation());
 		}
 	}

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1104,25 +1104,25 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 		tabs = new JTabbedPane(SwingConstants.BOTTOM);
 		tabs.addTab(null, ImageCache.getIcon("tab/record"), getActionPanel(), "Record Actions");
 		if (character.isCharacter())
-			tabs.addTab(null, ImageCache.getIcon("tab/chits"), getChitPanel(), "Chits");
+			tabs.addTab(null, ImageCache.getIcon("tab/chits"), getChitPanel(), "Toggle Chits View");
 		if (!character.isMinion())
-			tabs.addTab(null, ImageCache.getIcon("tab/inventory"), getInventoryObjectPanel(), "Inventory");
-		tabs.addTab(null, ImageCache.getIcon("tab/spells"), getSpellsPanel(), "Spells"); // hired leaders might be bewitched by spells...
-		tabs.addTab(null, ImageCache.getIcon("tab/disc"), getDiscoveriesPanel(), "Discoveries");
-		tabs.addTab(null, ImageCache.getIcon("tab/relationships"), getRelationshipPanel(), "Native Relationships");
+			tabs.addTab(null, ImageCache.getIcon("tab/inventory"), getInventoryObjectPanel(), "Toggle Inventory View");
+		tabs.addTab(null, ImageCache.getIcon("tab/spells"), getSpellsPanel(), "Toggle Spells View"); // hired leaders might be bewitched by spells...
+		tabs.addTab(null, ImageCache.getIcon("tab/disc"), getDiscoveriesPanel(), "Toggle Discoveries View");
+		tabs.addTab(null, ImageCache.getIcon("tab/relationships"), getRelationshipPanel(), "Toggle Native Relationships View");
 		if (!character.isMinion())
-			tabs.addTab(null, ImageCache.getIcon("tab/followers"), getHirelingPanel(), "Hirelings");
+			tabs.addTab(null, ImageCache.getIcon("tab/followers"), getHirelingPanel(), "Toggle Hirelings View");
 		if (character.isCharacter()) {
-			tabs.addTab(null, ImageCache.getIcon("tab/victoryreq"), getVictoryPanel(), "Victory Requirements");
-			tabs.addTab(null, ImageCache.getIcon("tab/notepad"), getNotesPanel(),"Character Notes");
+			tabs.addTab(null, ImageCache.getIcon("tab/victoryreq"), getVictoryPanel(), "Toggle Victory Requirements View");
+			tabs.addTab(null, ImageCache.getIcon("tab/notepad"), getNotesPanel(),"Toggle Character Notes View");
 		}
 		if (hostPrefs.getGameKeyVals().contains("rw_expansion_1")) {
-			tabs.addTab(null, ImageCache.getIcon("tab/expansionOne"), getExpansionOnePanel(),"Expansion");
+			tabs.addTab(null, ImageCache.getIcon("tab/expansionOne"), getExpansionOnePanel(),"Toggle Expansion View");
 		}
 		if (hostPrefs.isUsingQuests()) {
-			tabs.addTab(null, ImageCache.getIcon("tab/quest"), getQuestPanel(),"Quest");
+			tabs.addTab(null, ImageCache.getIcon("tab/quest"), getQuestPanel(),"Toggle Quest View");
 		}
-		tabs.addTab(null, ImageCache.getIcon("tab/chat"), getChatPanel(),"Chat");
+		tabs.addTab(null, ImageCache.getIcon("tab/chat"), getChatPanel(),"Toggle Chat View");
 
 		boolean[] tabChangedByThisPress = {false};
 		tabs.addChangeListener(e -> tabChangedByThisPress[0] = true);
@@ -1184,7 +1184,15 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 			if (transmorph != null) {
 				getCharacter().setTransmorph(null);
 			}
-			charLabel = new JLabel(chit.getMediumIcon());
+			charLabel = new JLabel(chit.getMediumIcon()) {
+				public String getToolTipText(MouseEvent ev) {
+					Icon icon = getIcon();
+					if (icon != null && ev.getX() <= getInsets().left + icon.getIconWidth()) {
+						return "Toggle between center-on-character and default view.";
+					}
+					return null;
+				}
+			};
 			if (resetHidden) {
 				chit.setHidden(true);
 			}
@@ -1193,7 +1201,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 			}
 			charLabel.setFont(new Font("Dialog", Font.BOLD, 36));
 			charLabel.setIconTextGap(10);
-			charLabel.setToolTipText("Toggle between center on character and revert.");
+			charLabel.setToolTipText("Toggle between center-on-character and default view.");
 			charLabel.addMouseListener(new MouseAdapter() {
 				public void mousePressed(MouseEvent ev) {
 					Icon icon = charLabel.getIcon();
@@ -2533,7 +2541,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 				SwingUtilities.invokeLater(new Runnable() {
 					public void run() {
 						gameOverPanel = new GameOverPanel(character.getGameObject(),hostPrefs);
-						tabs.addTab(null, ImageCache.getIcon("tab/gameover"), gameOverPanel, GameOverPanel.TAB_NAME);
+						tabs.addTab(null, ImageCache.getIcon("tab/gameover"), gameOverPanel, "Toggle " + GameOverPanel.TAB_NAME + " View");
 						tabs.setSelectedIndex(tabs.getTabCount() - 1);
 					}
 				});
@@ -2545,7 +2553,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 		SwingUtilities.invokeLater(new Runnable() { // This should get rid of the ArrayIndexOutOfBoundsException problem
 			public void run() {
 				for (int i = 0; i < tabs.getTabCount(); i++) {
-					if (GameOverPanel.TAB_NAME.equals(tabs.getToolTipTextAt(i))) {
+					if (("Toggle " + GameOverPanel.TAB_NAME + " View").equals(tabs.getToolTipTextAt(i))) {
 						tabs.removeTabAt(i);
 						tabs.setSelectedIndex(0);
 						break;

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1196,6 +1196,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 			}
 			charLabel.setFont(new Font("Dialog", Font.BOLD, 36));
 			charLabel.setIconTextGap(10);
+			charLabel.setToolTipText("Toggle between center on character and revert.");
 			charLabel.addMouseListener(new MouseAdapter() {
 				public void mousePressed(MouseEvent ev) {
 					Icon icon = charLabel.getIcon();

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1147,6 +1147,11 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 
 	public void centerOnToken() {
 		if (gameHandler.getGame().getGameStarted()) {
+			gameHandler.getInspector().getMap().centerOn(character.getCurrentLocation());
+		}
+	}
+	private void toggleCenterOnToken() {
+		if (gameHandler.getGame().getGameStarted()) {
 			CenteredMapView map = gameHandler.getInspector().getMap();
 			if (savedMapOffset != null) {
 				map.setOffset(savedMapOffset);
@@ -1811,7 +1816,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 	}
 
 	private void tokenClicked() {
-		centerOnToken();
+		toggleCenterOnToken();
 		if (DebugUtility.isCheat()) {
 			// If CHEAT is on, then clicking the token will allow you to cheat
 			cheat();

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -32,6 +32,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 
 	protected JPanel tokenPanel;
 	protected JLabel charLabel;
+	private java.awt.geom.Point2D.Double savedMapOffset = null;
 	protected MoveMarker mountainMoveIcon;
 	protected CharacterWrapper character;
 	protected HostPrefWrapper hostPrefs;
@@ -1146,7 +1147,16 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 
 	public void centerOnToken() {
 		if (gameHandler.getGame().getGameStarted()) {
-			gameHandler.getInspector().getMap().centerOn(character.getCurrentLocation());
+			CenteredMapView map = gameHandler.getInspector().getMap();
+			if (savedMapOffset != null) {
+				map.setOffset(savedMapOffset);
+				map.repaint();
+				savedMapOffset = null;
+			} else {
+				java.awt.geom.Point2D.Double cur = map.getOffset();
+				savedMapOffset = new java.awt.geom.Point2D.Double(cur.x, cur.y);
+				map.centerOn(character.getCurrentLocation());
+			}
 		}
 	}
 

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -32,7 +32,7 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 
 	protected JPanel tokenPanel;
 	protected JLabel charLabel;
-	private java.awt.geom.Point2D.Double savedMapOffset = null;
+	private boolean centeredOnToken = false;
 	protected MoveMarker mountainMoveIcon;
 	protected CharacterWrapper character;
 	protected HostPrefWrapper hostPrefs;
@@ -1153,15 +1153,12 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 	private void toggleCenterOnToken() {
 		if (gameHandler.getGame().getGameStarted()) {
 			CenteredMapView map = gameHandler.getInspector().getMap();
-			if (savedMapOffset != null) {
-				map.setOffset(savedMapOffset);
-				map.repaint();
-				savedMapOffset = null;
+			if (centeredOnToken) {
+				map.restoreDefaultView();
 			} else {
-				java.awt.geom.Point2D.Double cur = map.getOffset();
-				savedMapOffset = new java.awt.geom.Point2D.Double(cur.x, cur.y);
 				map.centerOn(character.getCurrentLocation());
 			}
+			centeredOnToken = !centeredOnToken;
 		}
 	}
 

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmInspectorFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmInspectorFrame.java
@@ -13,6 +13,7 @@ import com.robin.game.objects.GameData;
 import com.robin.general.swing.IconFactory;
 import com.robin.magic_realm.components.attribute.ChatLine;
 import com.robin.magic_realm.components.swing.CenteredMapView;
+import com.robin.magic_realm.components.swing.MapDefaultViewControl;
 import com.robin.magic_realm.components.utility.Constants;
 import com.robin.magic_realm.components.utility.RealmCalendar;
 import com.robin.magic_realm.components.wrapper.*;
@@ -88,7 +89,22 @@ public class RealmInspectorFrame extends RealmSpeakInternalFrame {
 			}
 		});
 
-		getContentPane().add(map,"Center");
+		// CenteredMapView overrides paint() directly without calling super.paint()/paintChildren(),
+		// so a Swing child added directly to map would never actually be painted. The "Default
+		// View"/"Set Default" overlay is therefore added as a SIBLING of map inside a JLayeredPane,
+		// on a higher layer so it floats on top and still receives its own click events.
+		JLayeredPane mapLayeredPane = new JLayeredPane();
+		mapLayeredPane.setLayout(null);
+		mapLayeredPane.add(map,JLayeredPane.DEFAULT_LAYER);
+		final MapDefaultViewControl defaultViewControl = new MapDefaultViewControl(map);
+		mapLayeredPane.add(defaultViewControl,JLayeredPane.PALETTE_LAYER);
+		mapLayeredPane.addComponentListener(new ComponentAdapter() {
+			public void componentResized(ComponentEvent ev) {
+				map.setBounds(0,0,mapLayeredPane.getWidth(),mapLayeredPane.getHeight());
+				defaultViewControl.reanchor(mapLayeredPane.getWidth(),mapLayeredPane.getHeight());
+			}
+		});
+		getContentPane().add(mapLayeredPane,"Center");
 		addKeyListener(map.getShiftKeyListener());
 		
 		zoomSlider = new JSlider(10,100,70);
@@ -141,6 +157,11 @@ public class RealmInspectorFrame extends RealmSpeakInternalFrame {
 			ex.printStackTrace();
 		}
 		map.centerMap();
+		if (!map.hasDefaultView()) {
+			// First time this map window is organized, the initial centered view becomes the
+			// default view (until the user explicitly overrides it with "Set Default").
+			map.setAsDefaultView();
+		}
 	}
 	public boolean onlyOneInstancePerGame() {
 		return true;

--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/swing/CenteredMapView.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/swing/CenteredMapView.java
@@ -91,6 +91,11 @@ public class CenteredMapView extends JComponent {
 	protected double scale = 1.0;
 	protected Rectangle normalMapRect;
 	protected Rectangle borderRect;
+
+	// Default view (pan/zoom) saved via the map window's "Set Default" button — in-memory only,
+	// for the lifetime of this CenteredMapView instance (not persisted across games or restarts).
+	private Point2D.Double defaultOffset = null;
+	private double defaultScale = -1;
 	
 	protected BufferedImage mapImage = null;
 	protected boolean replot = true;
@@ -908,6 +913,31 @@ public class CenteredMapView extends JComponent {
 	}
 	public void setOffset(Point2D.Double p) {
 		offset = p;
+	}
+	/**
+	 * Captures the current pan offset and zoom scale as this map's default view, for later recall
+	 * via {@link #restoreDefaultView()}. In-memory only — not persisted across games or restarts.
+	 */
+	public void setAsDefaultView() {
+		defaultOffset = new Point2D.Double(offset.x,offset.y);
+		defaultScale = scale;
+	}
+	public boolean hasDefaultView() {
+		return defaultOffset != null;
+	}
+	/**
+	 * Restores the view saved by {@link #setAsDefaultView()}. If nothing has been saved yet,
+	 * falls back to {@link #centerMap()} so the button is useful on first click too.
+	 */
+	public void restoreDefaultView() {
+		if (hasDefaultView()) {
+			scale = defaultScale;
+			offset = new Point2D.Double(defaultOffset.x,defaultOffset.y);
+			repaint();
+		}
+		else {
+			centerMap();
+		}
 	}
 	public void paint(Graphics g1) {
 		Graphics2D g = (Graphics2D)g1;

--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/swing/MapDefaultViewControl.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/swing/MapDefaultViewControl.java
@@ -1,0 +1,105 @@
+package com.robin.magic_realm.components.swing;
+
+import java.awt.*;
+import java.awt.event.*;
+
+import javax.swing.*;
+
+/**
+ * Small floating control shown over a {@link CenteredMapView}: "Default View" recalls a saved
+ * pan/zoom, "Set Default" saves the current one. Dragged via a dedicated grip handle so the
+ * buttons themselves only ever fire their click action — never a drag.
+ * <p>
+ * By default this control anchors to the lower-left corner of its container, tracking resizes,
+ * until the user drags it somewhere else (after which it stays put, only being clamped back into
+ * view if the container shrinks too far).
+ */
+public class MapDefaultViewControl extends JPanel {
+
+	public static final int MARGIN = 10;
+	private static final int GRIP_WIDTH = 14;
+
+	private boolean userPositioned = false;
+	private Point dragStartInPanel = null;
+
+	public MapDefaultViewControl(CenteredMapView map) {
+		super(new BorderLayout(2,0));
+		setOpaque(true);
+		setBorder(BorderFactory.createCompoundBorder(
+				BorderFactory.createLineBorder(Color.darkGray),
+				BorderFactory.createEmptyBorder(2,2,2,2)));
+
+		JComponent grip = createGripHandle();
+		add(grip,"West");
+
+		JPanel buttons = new JPanel(new GridLayout(1,2,4,0));
+		JButton defaultViewButton = new JButton("Default View");
+		defaultViewButton.setToolTipText("Recall the saved default view");
+		defaultViewButton.addActionListener(ev -> map.restoreDefaultView());
+		JButton setDefaultButton = new JButton("Set Default");
+		setDefaultButton.setToolTipText("Save the current pan/zoom as the default view");
+		setDefaultButton.addActionListener(ev -> map.setAsDefaultView());
+		buttons.add(defaultViewButton);
+		buttons.add(setDefaultButton);
+		add(buttons,"Center");
+	}
+
+	private JComponent createGripHandle() {
+		JComponent grip = new JComponent() {
+			protected void paintComponent(Graphics g) {
+				g.setColor(Color.darkGray);
+				for (int row=0;row<3;row++) {
+					for (int col=0;col<2;col++) {
+						g.fillRect(3+col*5,4+row*5,2,2);
+					}
+				}
+			}
+		};
+		grip.setPreferredSize(new Dimension(GRIP_WIDTH,10));
+		grip.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
+		grip.setToolTipText("Drag to move");
+
+		MouseAdapter dragHandler = new MouseAdapter() {
+			public void mousePressed(MouseEvent ev) {
+				dragStartInPanel = SwingUtilities.convertPoint(grip,ev.getPoint(),MapDefaultViewControl.this);
+			}
+			public void mouseDragged(MouseEvent ev) {
+				userPositioned = true;
+				Point nowInPanel = SwingUtilities.convertPoint(grip,ev.getPoint(),MapDefaultViewControl.this);
+				Point loc = getLocation();
+				moveTo(loc.x+(nowInPanel.x-dragStartInPanel.x), loc.y+(nowInPanel.y-dragStartInPanel.y));
+			}
+		};
+		grip.addMouseListener(dragHandler);
+		grip.addMouseMotionListener(dragHandler);
+		return grip;
+	}
+
+	/**
+	 * Moves to the given location, clamped within the parent's current bounds so the control
+	 * can never be dragged (or resized) entirely out of view.
+	 */
+	private void moveTo(int x,int y) {
+		Container parent = getParent();
+		if (parent!=null) {
+			x = Math.max(0,Math.min(x,parent.getWidth()-getWidth()));
+			y = Math.max(0,Math.min(y,parent.getHeight()-getHeight()));
+		}
+		setLocation(x,y);
+	}
+
+	/**
+	 * Called whenever the map container resizes. Re-anchors to the lower-left corner with margin
+	 * if the user has never dragged this control; otherwise just clamps the existing position so
+	 * a shrinking window can't strand it off-screen.
+	 */
+	public void reanchor(int containerWidth,int containerHeight) {
+		setSize(getPreferredSize());
+		if (userPositioned) {
+			moveTo(getX(),getY());
+		}
+		else {
+			setLocation(MARGIN,containerHeight-getHeight()-MARGIN);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Clicking a character's token icon toggles the map between centering on that character and a "default view".
- The default view is per-session (in-memory), automatically initialized to the map's first centered view when the window appears, and can be overridden any time via a new "Set Default" button.
- A small draggable overlay (lower-left of the map window, dragged via a dedicated grip handle) provides "Default View" (recall) and "Set Default" (save current pan/zoom) buttons.
- CHEAT mode and the token-click toggle are mutually exclusive per click — if CHEAT is active, clicking the token opens the cheat dialog instead of toggling the map view.

## Test plan
- [x] Start or load a game, open the map window, confirm the Default View/Set Default overlay appears lower-left and is draggable only via its grip handle (not by clicking the buttons themselves)
- [x] Click a character's token icon — map should center on that character
- [x] Click the token again — map should return to the default view
- [x] Click "Set Default" after panning/zooming somewhere else, then toggle off a centered character — should return to the newly set default
- [x] Resize the map window — overlay should stay anchored lower-left until manually dragged, then stay where dragged
- [ ] With CHEAT mode enabled, click a token — cheat dialog should open instead of toggling the map view