### PR TITLE
Fix RealmBattle->RealmSpeak dependency violation from combat controls placement option

### DIFF
--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
@@ -21,7 +21,6 @@ import com.robin.general.util.*;
 import com.robin.magic_realm.RealmBattle.MoveActivator.MoveActionResult;
 import com.robin.magic_realm.RealmBattle.targeting.SpellTargeting;
 import com.robin.magic_realm.RealmCharacterBuilder.RealmCharacterBuilderModel;
-import com.robin.magic_realm.RealmSpeak.RealmSpeakOptions;
 import com.robin.magic_realm.components.*;
 import com.robin.magic_realm.components.attribute.*;
 import com.robin.magic_realm.components.quest.CharacterActionType;
@@ -168,6 +167,7 @@ public class CombatFrame extends JFrame {
 	private CombatSuggestionAi suggestionAi;
 	private static boolean combatNextPhaseWarning = true;
 	private static boolean autoPositioningAttackers = false;
+	private static boolean controlsPlacement2 = false;
 	
 	// These are needed to differentiate all the players during results
 	private String playerName;
@@ -199,7 +199,10 @@ public class CombatFrame extends JFrame {
 	public static void setAutoPositioningAttackers(boolean val) {
 		autoPositioningAttackers = val;
 	}
-	
+	public static void setControlsPlacement2(boolean val) {
+		controlsPlacement2 = val;
+	}
+
 	protected static DieRoller ambushRoll = null;
 	protected static RealmComponent ambusher = null;
 	protected static boolean ambushRollAtEndOfCombatRound = false;
@@ -1079,7 +1082,7 @@ public class CombatFrame extends JFrame {
 		}
 		
 		list.add(getRefreshDisplayButton());
-		if (!new RealmSpeakOptions().getOptions().getBoolean(RealmSpeakOptions.COMBAT_CONTROLS_PLACEMENT_2)) {
+		if (!controlsPlacement2) {
 			list.add(gameControls);
 		}
 		
@@ -1300,7 +1303,7 @@ public class CombatFrame extends JFrame {
 		});
 		bottomPanel.add(combatSummaryButton,"Center");
 		gameControls = new JPanel(new GridLayout(2,2));
-		if (new RealmSpeakOptions().getOptions().getBoolean(RealmSpeakOptions.COMBAT_CONTROLS_PLACEMENT_2)) {
+		if (controlsPlacement2) {
 			bottomPanel.add(gameControls,"South");
 		}
 

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakOptions.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmSpeakOptions.java
@@ -142,6 +142,7 @@ public class RealmSpeakOptions {
 		}
 		CenteredMapView.setFollowEnabled(options.getBoolean(MAP_FOLLOW_CHARACTER));
 		CombatFrame.setAutoPositioningAttackers(options.getBoolean(AUTO_POSITIONING_ATTACKERS));
+		CombatFrame.setControlsPlacement2(options.getBoolean(COMBAT_CONTROLS_PLACEMENT_2));
 		SoundCache.setSoundEnabled(options.getBoolean(ENABLE_SOUND,true));
 		if (options.getBoolean(RealmSpeakOptions.METAL_LNF)) {
 			ComponentTools.setMetalLookAndFeel();


### PR DESCRIPTION
## Summary
- `955e8d26` ("Alternative Placement for combat buttons") added `import com.robin.magic_realm.RealmSpeak.RealmSpeakOptions;` to `CombatFrame.java`, but `RealmBattle` does not depend on `RealmSpeak` (and is built *before* it in the module dependency order), so this breaks any clean build of `RealmBattle.jar`: `package com.robin.magic_realm.RealmSpeak does not exist`.
- Fixes it by mirroring the existing `setAutoPositioningAttackers()` pattern already used a few lines above it: a local static field/setter on `CombatFrame`, set from `RealmSpeakOptions.apply()` (which already depends on `RealmBattle`, so that direction is fine) instead of `CombatFrame` reaching up into `RealmSpeak` directly.
- The two `if` conditions in `CombatFrame.java` are unchanged in logic - only the value source changed (local static field instead of a fresh `RealmSpeakOptions` lookup each time) - so behavior should be identical.

## Test plan
- [x] `ant clean-build-RealmBattle` succeeds with no `RealmSpeak.jar`/`RealmSpeakFull.jar` present at all (confirms the dependency is genuinely gone, not just masked by stale jars)
- [x] Full `ant` build succeeds
- [ ] Have **not** done an end-to-end manual check of toggling "Combat Controls - alternative placement" in a live combat window - reaching combat requires a full game session I haven't set up. The option's UI control, persistence key, and read/write logic are untouched by this diff, so I'd expect no behavior change, but flagging this as unverified rather than claiming it.