### PR TITLE
Fix StealReward->RealmBattle dependency violation (unused import)

### DIFF
--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/table/StealReward.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/table/StealReward.java
@@ -8,7 +8,6 @@ import javax.swing.JOptionPane;
 import com.robin.game.objects.GameObject;
 import com.robin.general.swing.DieRoller;
 import com.robin.general.util.RandomNumber;
-import com.robin.magic_realm.RealmBattle.check;
 import com.robin.magic_realm.components.*;
 import com.robin.magic_realm.components.store.GuildStore;
 import com.robin.magic_realm.components.store.ThievesGuild;


### PR DESCRIPTION
## Summary

- `StealReward.java` in `magic_realm/utility/components/` imported `com.robin.magic_realm.RealmBattle.check` — an upward dependency from the utility layer into the applications layer, violating the module hierarchy (`general` → `game` → `magic_realm/utility` → `magic_realm/applications`).
- The import was unused (no reference to `check` anywhere in the file body), so the fix is a single-line deletion.
- Same pattern as PR #35 (`CombatFrame.java` importing `RealmSpeakOptions`).

## Test plan

- [ ] Build `RealmBattle` module in isolation (with `RealmSpeak.jar`/`RealmSpeakFull.jar` absent from `products/`) — confirms `realm_components` no longer needs the applications layer to compile.
- [ ] Full build (`ant clean-build-RealmSpeakFull`) succeeds.