### PR TITLE
Fix offroad travel: missing Chasm tile data + backspace removes only one of two action slots

### DIFF
--- a/data/MagicRealmData.xml
+++ b/data/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />

--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterActionControlManager.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterActionControlManager.java
@@ -506,9 +506,13 @@ public class CharacterActionControlManager {
 		
 		ArrayList<String> actions = new ArrayList<>();
 		Collection<String> c = getCharacter().getCurrentActions();
+		String removed = null;
 		if (c!=null && !c.isEmpty()) {
 			actions.addAll(c);
-			String removed = actions.remove(actions.size()-1);
+			removed = actions.remove(actions.size()-1);
+			if (removed.startsWith(DayAction.OFFROAD_TRAVEL_ACTION.getCode())) {
+				actions.remove(actions.size()-1);
+			}
 			if (removed.startsWith(DayAction.MOVE_ACTION.getCode()) || removed.startsWith(DayAction.FLY_ACTION.getCode())) {
 				// deleting a move, so delete a clearing plot
 				getCharacter().chompClearingPlot();
@@ -538,6 +542,9 @@ public class CharacterActionControlManager {
 		if (c!=null && !c.isEmpty()) {
 			actionTypeCodes.addAll(c);
 			actionTypeCodes.remove(actionTypeCodes.size()-1);
+			if (removed != null &&  removed.startsWith(DayAction.OFFROAD_TRAVEL_ACTION.getCode())) {
+				actionTypeCodes.remove(actionTypeCodes.size()-1);
+			}
 		}
 		getCharacter().setCurrentActionTypeCodes(actionTypeCodes);
 		

--- a/magic_realm/utility/components/resources/data/MagicRealmData.xml
+++ b/magic_realm/utility/components/resources/data/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />

--- a/products/gameData/MagicRealmData.xml
+++ b/products/gameData/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />


### PR DESCRIPTION
## Summary

Two independent bugs in the existing offroad travel feature, both present in the current codebase.

### Bug 1 — Chasm tiles missing offroad side data (`MagicRealmData.xml`)

Both Chasm tile game objects (IDs 889 and 1149 — the two physical copies used in setup) declare `offroad_travel_sides=""` in their `this` AttributeBlock, meaning offroad travel is supported on those tiles. However, neither the `normal` nor `enchanted` sides had the required `offroad_travel_side_1` / `offroad_travel_side_2` attribute lists that map each tile-entry side to the clearings it connects to. Attempting offroad travel on a Chasm tile would fail at runtime because that per-side clearing data was entirely absent.

The fix adds the side-to-clearing mappings for both copies of the Chasm tile, on both normal and enchanted sides.

### Bug 2 — Backspace removes only one of two offroad travel action slots (`CharacterActionControlManager.java`)

Offroad travel is recorded with `doRecord(OFFROAD_TRAVEL_ACTION, null, cost=2, count=1)`. With `cost=2`, `doRecord` writes **two** entries into the character's action list — the same pattern used for mountain moves (cost 2) and weather moves (cost 3). When the player presses backspace to remove the last recorded action, the original code removed only the final entry from both `actions` and `actionTypeCodes`, leaving the first phantom offroad slot behind and corrupting the action plan for the rest of the day.

The fix checks whether the removed entry started with `OFFROAD_TRAVEL_ACTION`'s code and, if so, removes the preceding entry as well — applied consistently to both lists.

## Test plan

- [ ] Record an offroad travel action, then press backspace — confirm both action slots are removed cleanly and the action plan is not corrupted
- [ ] Use offroad travel on a Chasm tile (both normal and enchanted sides) — confirm the clearing options appear correctly and the move completes
- [ ] Verify normal Move backspace still works (remove a mountain move, confirm only its two slots are removed; remove a plain move, confirm only one slot removed)