### PR TITLE
Fix offroad travel on Chasm tiles: add missing side-to-clearing data

### DIFF
--- a/data/MagicRealmData.xml
+++ b/data/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />

--- a/magic_realm/utility/components/resources/data/MagicRealmData.xml
+++ b/magic_realm/utility/components/resources/data/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />

--- a/products/gameData/MagicRealmData.xml
+++ b/products/gameData/MagicRealmData.xml
@@ -22979,6 +22979,16 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="52.2,16.5" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="29.0,26.5" />
@@ -23033,6 +23043,16 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="3" />
+          <attributeVal N2="4" />
+          <attributeVal N3="6" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+        </attributeList>
         <attribute offroad_xy="45.5,12.8" />
         <attribute clearing_1_type="normal" />
         <attribute clearing_1_xy="28.2,27.7" />
@@ -31381,6 +31401,17 @@
         <attribute offroad_travel_sides="" />
       </AttributeBlock>
       <AttributeBlock blockName="normal">
+	    <attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="33.6,21.6" />
@@ -31442,6 +31473,17 @@
         </attributeList>
       </AttributeBlock>
       <AttributeBlock blockName="enchanted">
+	  	<attributeList keyName="offroad_travel_side_1">
+          <attributeVal N0="1" />
+          <attributeVal N1="2" />
+          <attributeVal N2="3" />
+          <attributeVal N3="4" />
+        </attributeList>
+        <attributeList keyName="offroad_travel_side_2">
+          <attributeVal N0="2" />
+          <attributeVal N1="5" />
+          <attributeVal N2="6" />
+        </attributeList>
         <attribute offroad_xy="66.5,9.7" />
         <attribute clearing_1_type="woods" />
         <attribute clearing_1_xy="34.4,21.9" />


### PR DESCRIPTION
## Summary

Both Chasm tiles (`name="Chasm"`, IDs 889 and 1149 — the two physical copies) declare `offroad_travel_sides=""` in their `this` AttributeBlock, marking them as offroad-travel-capable. However, neither the `normal` nor `enchanted` sides had the `offroad_travel_side_1` / `offroad_travel_side_2` attribute lists that map each tile-entry side to its accessible clearings.

## How the crash occurs

`OffroadTravel.getClearingsOfSameSide()` iterates `offroad_travel_side_0..5` in the current tile's stat-side AttributeBlock looking for which group contains the character's current clearing number. When none of those lists exist it returns `null`.

Two callers dereference that return value without a null guard:

- `chooseClearing()` — `for (String num : getClearingsOfSameSide())` → NullPointerException
- `randomClearing()` — `getClearingsOfSameSide().size()` → NullPointerException

Because the Chasm has `offroad_travel_sides=""` in its `this` block, `hasThisAttribute(OFFROAD_TRAVEL_SIDES)` is `true` and the side-data branch is always taken — there is no fallback to the generic all-clearings path.

## Failure conditions

All three must be true for the crash to occur:

1. A Chasm tile is on the board (not guaranteed — depends on setup draw)
2. A character with ORT ability is in a clearing on that tile and executes ORT
3. The die roll lands on **2, 3, or 4** (which call `chooseClearing` or `randomClearing` directly), **or** a roll of **1** where the player then picks "Choose Clearing" or "Random Clearing" from the sub-choice dialog

Rolls of 5 or 6 resolve to "Lost" and never access the side data — no crash. This makes the bug easy to miss in testing.

## Fix

Adds `offroad_travel_side_1` and `offroad_travel_side_2` attribute lists to the `normal` and `enchanted` AttributeBlocks of both Chasm tiles, matching the physical tile layout.

## Test plan

- [ ] Place a Chasm tile during setup; move a character with ORT into a Chasm clearing
- [ ] Execute ORT and verify die results 2, 3, and 4 each present a clearing-selection UI without crashing
- [ ] Verify a roll of 1 with sub-choice "Choose Clearing" or "Random Clearing" also works
- [ ] Verify rolls of 5 and 6 (Lost) still work as before
- [ ] Verify ORT on non-Chasm tiles is unaffected