### PR TITLE
Fix Guide Spider/Octopus spell not targeting Expansion 1 Gargrath Spider

### DIFF
--- a/data/MagicRealmData.xml
+++ b/data/MagicRealmData.xml
@@ -24638,6 +24638,7 @@
         <attribute fame="7" />
         <attribute notoriety="7" />
         <attribute icon_type="spider" />
+        <attribute spider="" />
         <attribute setup_start="Web" />
         <attribute monster_die="5" />
         <attribute base_price="10" />

--- a/magic_realm/utility/components/resources/data/MagicRealmData.xml
+++ b/magic_realm/utility/components/resources/data/MagicRealmData.xml
@@ -24638,6 +24638,7 @@
         <attribute fame="7" />
         <attribute notoriety="7" />
         <attribute icon_type="spider" />
+        <attribute spider="" />
         <attribute setup_start="Web" />
         <attribute monster_die="5" />
         <attribute base_price="10" />

--- a/products/gameData/MagicRealmData.xml
+++ b/products/gameData/MagicRealmData.xml
@@ -24638,6 +24638,7 @@
         <attribute fame="7" />
         <attribute notoriety="7" />
         <attribute icon_type="spider" />
+        <attribute spider="" />
         <attribute setup_start="Web" />
         <attribute monster_die="5" />
         <attribute base_price="10" />


### PR DESCRIPTION
## Summary

The Witch's **Guide Spider or Octopus** spell had no effect on the Expansion 1 Gargrath Spider when cast in the Web.

## Root cause

`SpellTargetingSpiderOctopus` identifies valid targets via `hasThisAttribute(Constants.SPIDER)`, which looks for a `spider=""` attribute in the monster's `this` AttributeBlock. The Gargrath had `icon_type="spider"` (for display purposes) but was missing the `spider=""` attribute that marks it as a spider for spell targeting. All base-game spiders (T Spider, H Spider) have this attribute; Gargrath did not.

## Fix

Add `<attribute spider="" />` to the Gargrath's `this` AttributeBlock in `MagicRealmData.xml`, consistent with T Spider and H Spider.

## Test plan

- [ ] Cast Guide Spider or Octopus spell against a Gargrath Spider in the Web — confirm it is now a valid target and the spell takes effect
- [ ] Confirm Guide Spider or Octopus still targets T Spider and H Spider correctly
- [ ] Confirm the spell still does not target non-spider monsters