### PR TITLE
Fix Hound companion cloning and ghost rendering

### DIFF
--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/utility/TreasureUtility.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/utility/TreasureUtility.java
@@ -957,6 +957,7 @@ public class TreasureUtility {
 						character.removeHireling(companion);
 						SetupCardUtility.resetDenizen(companion);
 						thing.removeThisAttribute(Constants.SUMMON_COMPANION_ID);
+						companion.detach();
 						data.removeObject(companion);
 					}
 					else {

--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/utility/TreasureUtility.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/utility/TreasureUtility.java
@@ -364,7 +364,8 @@ public class TreasureUtility {
 					return false;
 				}
 			}
-			if (thing.hasThisAttribute(Constants.SUMMON_COMPANION) && !thing.hasThisAttribute(Constants.POTION)) {
+			if (thing.hasThisAttribute(Constants.SUMMON_COMPANION) && !thing.hasThisAttribute(Constants.POTION)
+					&& !thing.hasThisAttribute(Constants.SUMMON_COMPANION_ID)) {
 				GameObject companion = getCompanionFromItem(thing);
 				character.addHireling(companion,Constants.TEN_YEARS);
 				CombatWrapper combat = new CombatWrapper(companion);


### PR DESCRIPTION
## Summary

- `doActivate()` had no guard preventing duplicate companion creation when called on an already-active `SUMMON_COMPANION` item. `PhaseManager.manageInactiveInventoryRequirement()` calls `doActivate()` with `process=false` on every BirdSong for item-based recorded actions, bypassing the `active.contains()` check — spawning a new orphaned Hound companion each day the item stayed active. Fix: skip companion creation if `SUMMON_COMPANION_ID` is already set.
- `doDeactivate()` called `data.removeObject(companion)` without first calling `companion.detach()`. Since `GameData.removeObject()` intentionally does not detach objects from their parent holds, the deactivated companion remained as a ghost in the clearing's hold, rendering visually alongside the newly-created replacement. Fix: call `companion.detach()` before `data.removeObject()`.

## Test plan

- [x] Acquire Hound treasure item as any character
- [x] Activate Hound — companion appears in clearing
- [x] Deactivate Hound — companion disappears from clearing (no ghost)
- [x] Activate Hound again — exactly one companion in clearing, one in Hirelings tab
- [x] Play several turns with Hound active — confirm no additional companions accumulate across BirdSong cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)