### PR TITLE
Fix generated monsters never being unblocked at day end

### DIFF
--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmHostPanel.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmHostPanel.java
@@ -873,9 +873,20 @@ public class RealmHostPanel extends JPanel {
 			
 		if (!doneTrading) return; // Don't continue if there is still day end trading going on
 		
-		// Unblock all monsters (this might be overkill, but maybe its not a big deal)
+		/*
+		 * Unblock all monsters (this might be overkill, but maybe its not a big deal).
+		 *
+		 * Do NOT filter this query on getGameKeyVals().  Monsters created at runtime - anything a
+		 * generator (Pond/Hive/Tomb) spawns through MonsterCreator - are never stamped with the game
+		 * keyVals, so a keyVals-scoped query silently skips every one of them.  Their "blocked" flag
+		 * was then set once by updateMonsterBlock() and never cleared again, which stopped them both
+		 * propagating (SetupCardUtility.moveGeneratedMonster returns immediately on isBlocked) and
+		 * prowling (the prowl loop in summonMonsters excludes blocked monsters) for the rest of the
+		 * game.  Unblocking a monster is harmless whichever content set it came from, and the
+		 * isMonster() test below still keeps non-monsters out.
+		 */
 		GamePool pool = new GamePool(host.getGameData().getGameObjects());
-		for (GameObject go:pool.find(hostPrefs.getGameKeyVals() + ",monster")) {
+		for (GameObject go:pool.find("monster")) {
 			RealmComponent rc = RealmComponent.getRealmComponent(go);
 			if (rc.isMonster()) {
 				MonsterChitComponent monster = (MonsterChitComponent) rc;


### PR DESCRIPTION
## The problem

Monsters spawned by a generator (Pond / Hive / Tomb) — Blobs, Wasps, Undead — can become permanently frozen. Once such a monster blocks a character, it never moves again for the rest of the game: it stops propagating across the map *and* stops prowling within its tile.

## Root cause

The day-end unblock loop in `RealmHostPanel.updateGameStateMidnight()` was:

```java
for (GameObject go : pool.find(hostPrefs.getGameKeyVals() + ",monster")) {
    RealmComponent rc = RealmComponent.getRealmComponent(go);
    if (rc.isMonster()) {
        ((MonsterChitComponent)rc).setBlocked(false);
    }
}
```

Monsters created at runtime by `MonsterCreator` (via `SetupCardUtility.generateMonsters()`) are never stamped with the game keyVals, so this keyVals-scoped query skips every one of them.

`blocked` is set by `SetupCardUtility.updateMonsterBlock()` when a monster blocks a character, and this loop is the only thing that ever clears it — so for generated monsters it was never cleared at all. Being blocked then stops the monster twice over:

- `SetupCardUtility.moveGeneratedMonster()` returns immediately on `isBlocked()`
- the prowling-monster loop in `summonMonsters()` excludes blocked monsters

## Evidence

Confirmed against a saved game with game keyVals `rw_expansion_1`:

- ordinary setup-card monsters (e.g. `Goblin#2923`) carry the `rw_expansion_1` attribute
- **0 of 32 generated monsters carried it**

Observed in play as pods of Blobs and Undead that stopped moving permanently, including well after the character that blocked them had left the clearing.

## The fix

Drop the keyVals filter:

```java
for (GameObject go : pool.find("monster")) {
```

This is safe because:

- the existing `if (rc.isMonster())` test still keeps non-monsters out of the loop
- the method's stated intent is already indiscriminate — *"Unblock all monsters (this might be overkill, but maybe its not a big deal)"*
- unblocking a monster belonging to another content set is a no-op in practice

There are no other `getGameKeyVals() + ",monster"` queries in the tree, so this is the only affected site.

## Verifying

In a game with a discovered generator: let a generated monster block a character, then play through to the next day. Before this change it stayed blocked forever; after, it is unblocked at day end and resumes moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)