### PR TITLE
Show POPUP_MESSAGE dialogs on the EDT, not the GameClient thread

### DIFF
--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/RealmGameHandler.java
@@ -1057,7 +1057,16 @@ public class RealmGameHandler extends RealmSpeakInternalFrame {
 			});
 		}
 		else if (RealmDirectInfoHolder.POPUP_MESSAGE.equals(command)) {
-			RealmUtility.popupMessage(CombatFrame.getSingleton(), info);
+			// Run on the EDT, for the same reason as the branches above: handleDirectInfo() is called
+			// from the GameClient thread (GameClient.handleResponse -> receiveInfoDirect), and
+			// popupMessage() shows a MODAL dialog.  Calling it directly here stops that client
+			// polling until the player clicks OK, so the server's SO_TIMEOUT (GameNet.DEFAULT_TIMEOUT_MS)
+			// tears the connection down underneath them - seen as "Broken pipe" and a dead client with
+			// every window closed.  invokeLater lets handleDirectInfo() return immediately so polling
+			// continues while the dialog is up.
+			SwingUtilities.invokeLater(() -> {
+				RealmUtility.popupMessage(CombatFrame.getSingleton(), info);
+			});
 		}
 		else if (RealmDirectInfoHolder.HOST_NEED_EMAIL.equals(command)) {
 			RealmDirectInfoHolder infoResponse = new RealmDirectInfoHolder(getClient().getGameData(), getClient().getClientName());


### PR DESCRIPTION
## The problem

A player who leaves a popup dialog open for more than ten seconds loses their connection. The client dies with `Broken pipe`, `submitChanges()` starts reporting `This client is DEAD!`, and `RealmGameHandler` tears down every window — leaving an empty grey frame with nothing to explain what happened.

Nothing is wrong with the network. Reading the dialog is enough to lose the game.

## Root cause

`handleDirectInfo()` is called from the **GameClient networking thread**, via `GameClient.handleResponse()` → `receiveInfoDirect()` (`GameClient.java:268`). The `POPUP_MESSAGE` branch called `RealmUtility.popupMessage()` directly from there, and that shows a **modal** `JOptionPane`.

So the dialog blocked the client's polling loop until the player clicked OK. Once that exceeded `GameNet.DEFAULT_TIMEOUT_MS` (10 s), the server's `SO_TIMEOUT` fired, it decided the client was dead and closed the socket. The client's next write then failed with `Broken pipe`.

## Why this fix matches existing practice

`handleDirectInfo()` already contains three `invokeLater` blocks, two of them added for exactly this hazard:

- `SPELL_AFFECT_TARGETS_EXPIRE_IMMEDIATE` — *"Run on the EDT so that any blocking dialog (e.g. TileLocationChooser for Teleport) does not stall the GameClient thread and cause the server to time out"*
- `QUERY_YN` — *"THREADING: this branch runs on the GameClient thread … via invokeLater so handleDirectInfo() returns immediately, unblocking the GameClient thread. The GameClient continues polling normally while the user thinks."*

`POPUP_MESSAGE` was the remaining branch in that method that could still block the thread. This change brings it in line, using the same lambda form as its neighbours.

## The fix

```java
else if (RealmDirectInfoHolder.POPUP_MESSAGE.equals(command)) {
    SwingUtilities.invokeLater(() -> {
        RealmUtility.popupMessage(CombatFrame.getSingleton(), info);
    });
}
```

`handleDirectInfo()` now returns immediately and the GameClient thread keeps polling while the dialog is up. `info` is never reassigned in the method, so it is effectively final and safe to capture.

## Scope

Reachable from anything reporting through this channel — notably the table-result popups sent by `RealmTable.sendMessage()`, which go to another player's client.

## Verifying

Trigger any popup that arrives over `POPUP_MESSAGE` and leave it open for more than ten seconds before dismissing it. Before this change the client is dead by the time you click OK; after, play continues normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)