### PR TITLE
Initialise tile adjacency on demand instead of only via the map view

### DIFF
--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/TileComponent.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/TileComponent.java
@@ -85,7 +85,19 @@ public class TileComponent extends ChitComponent {
 	private boolean alwaysPaint = false;
 	private boolean needsRepaint = true;
 
+	/*
+	 * Tile adjacency is a CACHE, not a derived value - edgeTiles is filled only by
+	 * ClearingUtility.initAdjacentTiles().  Its long-standing caller is CenteredMapView, so adjacency
+	 * happens to be populated on a client as a side effect of building the map view.  Code working
+	 * against a GameData that never builds one - the host has its own GameData and its own
+	 * RealmComponent cache - saw every tile report ZERO neighbours instead.  That is indistinguishable
+	 * from "this tile really is isolated", so callers could not tell they were being handed nothing.
+	 *
+	 * adjacencyInitAttempted lets the accessors below populate the cache on demand, so adjacency is
+	 * correct for every caller rather than only for callers that remember to prime it first.
+	 */
 	private Hashtable<String,TileComponent> edgeTiles = new Hashtable<>();
+	private boolean adjacencyInitAttempted = false;
 
 	private Rectangle lastPaintLocation = null;
 	private Point[] lastOffroadPaintLocation = new Point[2];
@@ -1120,20 +1132,40 @@ public class TileComponent extends ChitComponent {
 
 	public void clearAdjacentTiles() {
 		edgeTiles.clear();
+		// initAdjacentTiles() clears then refills every tile in the map grid, so re-arm the lazy path
+		// for any tile that legitimately ends up with no neighbours (e.g. mid map build).
+		adjacencyInitAttempted = false;
 	}
 	public void putAdjacentTile(String rotatedEdge, TileComponent c) {
 		edgeTiles.put(rotatedEdge, c);
 	}
 
+	/**
+	 * Populates the adjacency cache from this tile's GameData if nobody has done so yet.  Tried at
+	 * most once per tile between explicit initAdjacentTiles() calls, so a tile that is genuinely not
+	 * on the map grid does not rebuild the grid on every query.
+	 */
+	private void ensureAdjacentTiles() {
+		if (!edgeTiles.isEmpty() || adjacencyInitAttempted) return;
+		adjacencyInitAttempted = true;
+		GameObject go = getGameObject();
+		if (go!=null && go.getGameData()!=null) {
+			ClearingUtility.initAdjacentTiles(go.getGameData());
+		}
+	}
+
 	public TileComponent getAdjacentTile(String rotatedEdge) {
+		ensureAdjacentTiles();
 		return edgeTiles.get(rotatedEdge);
 	}
 
 	public Collection<TileComponent> getAllAdjacentTiles() {
+		ensureAdjacentTiles();
 		return edgeTiles.values();
 	}
 
 	public int getEdgeTileCount() {
+		ensureAdjacentTiles();
 		return edgeTiles.size();
 	}
 

--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/utility/SetupCardUtility.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/utility/SetupCardUtility.java
@@ -541,6 +541,12 @@ public class SetupCardUtility {
 				choices.put(distanceFromHome,adj);
 			}
 			
+			if (choices.isEmpty()) {
+				// No adjacent tiles at all, so furthest is still Integer.MIN_VALUE and getList() below
+				// would return null.  Nothing to fly to - stay put rather than throw.
+				return;
+			}
+
 			// Randomly choose from furthest locations
 			ArrayList<TileComponent> finalChoices = choices.getList(furthest);
 			int r = RandomNumber.getRandom(finalChoices.size());


### PR DESCRIPTION
## The problem

`TileComponent.edgeTiles` is a **cache, not a derived value**. Nothing computes adjacency on demand — it is populated only by `ClearingUtility.initAdjacentTiles()`, and the long-standing caller of that is `CenteredMapView`.

So tile adjacency is correct on a client purely as a **side effect of building the map view**. Any code working against a `GameData` that never builds one sees every tile report **zero** adjacent tiles. The host is the obvious case: it has its own `GameData`, and therefore its own `RealmComponent` cache, entirely separate from the map view's.

This fails silently, because an empty result is indistinguishable from *"this tile really is isolated"*. Callers cannot tell they are being handed nothing.

## Concrete failure

`SetupCardUtility.moveGeneratedMonster()` throws for **flying** generated monsters:

```java
for (TileComponent adj : current.tile.getAllAdjacentTiles()) {   // empty
    ...
    furthest = Math.max(furthest, distanceFromHome);
    choices.put(distanceFromHome, adj);
}

ArrayList<TileComponent> finalChoices = choices.getList(furthest);  // furthest is still Integer.MIN_VALUE -> null
int r = RandomNumber.getRandom(finalChoices.size());                // NullPointerException
```

Simply null-guarding that would trade the crash for a subtler bug — fliers would never find anywhere to move, and would silently freeze.

## This hole is already known

`RealmEvents.chooseRandomAndAdjacentTiles()` works around it by calling `initAdjacentTiles(data)` itself, immediately before using `getAllAdjacentTiles()`:

```java
public static ArrayList<TileComponent> chooseRandomAndAdjacentTiles(GameData data) {
    ClearingUtility.initAdjacentTiles(data);
    ...
}
```

That works, but it means every caller must know to prime the cache first — which is easy to miss and gives no signal when you do.

## The fix

Have the three accessors populate the cache on demand:

```java
private void ensureAdjacentTiles() {
    if (!edgeTiles.isEmpty() || adjacencyInitAttempted) return;
    adjacencyInitAttempted = true;
    GameObject go = getGameObject();
    if (go != null && go.getGameData() != null) {
        ClearingUtility.initAdjacentTiles(go.getGameData());
    }
}
```

Applied to `getAllAdjacentTiles()`, `getAdjacentTile()` and `getEdgeTileCount()`.

Design notes:

- **Attempted-once, not empty-once.** A tile genuinely off the map grid legitimately has no neighbours; guarding on emptiness alone would rebuild the whole grid on every query.
- **`clearAdjacentTiles()` re-arms the flag**, so an explicit `initAdjacentTiles()` still takes precedence. That keeps things correct while a map is being built and tiles are moving.
- **No recursion** — `initAdjacentTiles()` calls `getRealmComponent()` and `putAdjacentTile()`, never the accessors.
- Existing explicit `initAdjacentTiles()` calls keep working unchanged; they simply become redundant rather than required.

Also guards the empty-candidate case in `moveGeneratedMonster()`'s flying branch as a backstop, so a tile that really is off-grid makes the monster stay put rather than throw.

## Verifying

With a generator (Hive) discovered and flying generated monsters on the map, run the generator's movement from a context with no map view — on the host. Before this change that throws `NullPointerException` on `finalChoices.size()`; after, the monster evaluates its adjacent tiles and moves normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)