### PR TITLE
Allow a longer socket timeout for the client login sync

### DIFF
--- a/game/utility/game_server/source/com/robin/game/server/GameClient.java
+++ b/game/utility/game_server/source/com/robin/game/server/GameClient.java
@@ -329,7 +329,9 @@ public abstract class GameClient extends GameNet {
 			logger.info("attempt "+attempts);
 			try {
 				connection = new Socket(ipAddress,port);
-				connection.setSoTimeout(GameNet.DEFAULT_TIMEOUT_MS);
+				// Generous while logging in - see CLIENT_LOGIN_TIMEOUT_MS.  run() restores
+				// DEFAULT_TIMEOUT_MS once the login sync has completed.
+				connection.setSoTimeout(GameNet.CLIENT_LOGIN_TIMEOUT_MS);
 				logger.info("Client connected");
 			}
 			catch(IOException ex) {
@@ -363,6 +365,14 @@ public abstract class GameClient extends GameNet {
 				logger.info("GameClient "+clientName+": logged in");
 				// Send name information
 				doRequest(new RequestObject(SUBMIT_LOGIN));
+				/*
+				 * The login sync is finished - that request is where the server ships the entire
+				 * masterData-to-gameData diff in one blocking read, and it is the only legitimately
+				 * slow response.  Everything from here on is REQUEST_IDLE polling, so go back to the
+				 * normal timeout: a long timeout during play only delays noticing a dead server, and
+				 * leaves the client outliving the server's own SO_TIMEOUT on the same connection.
+				 */
+				try { connection.setSoTimeout(GameNet.DEFAULT_TIMEOUT_MS); } catch(SocketException ex) { /* keep the login value */ }
 				connected = true;
 				
 				fireStateChanged();

--- a/game/utility/game_server/source/com/robin/game/server/GameNet.java
+++ b/game/utility/game_server/source/com/robin/game/server/GameNet.java
@@ -6,6 +6,14 @@ import java.util.ArrayList;
 
 public abstract class GameNet extends Thread {
 	public static int DEFAULT_TIMEOUT_MS = 10000;
+	/**
+	 * Client-side SO_TIMEOUT for the LOGIN SYNC ONLY.  That one request has the server ship the whole
+	 * masterData-to-gameData diff in a single blocking read, which on a large saved game runs well
+	 * past DEFAULT_TIMEOUT_MS; a client that gives up there dies mid-load and never recovers.
+	 * GameClient.run() drops the socket back to DEFAULT_TIMEOUT_MS as soon as that request returns,
+	 * so ordinary play keeps the short timeout.
+	 */
+	public static int CLIENT_LOGIN_TIMEOUT_MS = 120000; // 2 minutes
 	
 	protected Socket connection;
 	protected ObjectOutputStream out = null;


### PR DESCRIPTION
## The problem

A client joining a game can die during the initial load:

```
java.net.SocketTimeoutException: Read timed out
    at com.robin.game.server.GameClient.handleResponse(GameClient.java:245)
    at com.robin.game.server.GameClient.doRequest(...)
    at com.robin.game.server.GameClient.run(...)
```

It does not recover. The `GameClient` thread exits, and the window then sits there looking as though it is still loading — the EDT is idle and there is no client thread left to make progress. Nothing on screen explains what happened.

## Root cause

The client socket was given `DEFAULT_TIMEOUT_MS` (10 seconds) for its entire life:

```java
connection = new Socket(ipAddress, port);
connection.setSoTimeout(GameNet.DEFAULT_TIMEOUT_MS);
```

That is the right value for the `REQUEST_IDLE` polling that makes up normal play — a ~50 ms cycle that should never take ten seconds.

But `SUBMIT_LOGIN` is not like the rest. It is the request where the server ships the **entire `masterData` → `gameData` diff in a single blocking read**. On a large saved game that alone exceeds ten seconds, so the client gives up mid-load.

## The fix

Use a generous timeout for the login sync **only**, and restore `DEFAULT_TIMEOUT_MS` the moment `SUBMIT_LOGIN` returns:

```java
doRequest(new RequestObject(SUBMIT_LOGIN));
try { connection.setSoTimeout(GameNet.DEFAULT_TIMEOUT_MS); } catch(SocketException ex) { }
connected = true;
```

| Phase | Client timeout |
|---|---|
| Connect + login sync | `CLIENT_LOGIN_TIMEOUT_MS` (2 min) |
| Normal play | `DEFAULT_TIMEOUT_MS` (10 s), unchanged |

## Why not simply raise the timeout

Keeping the long value for the whole session would be worse than the bug it fixes:

- It only delays noticing a genuinely dead server — two minutes instead of ten seconds, for the entire session.
- It makes the two ends asymmetric. The server sets its own `SO_TIMEOUT` to `DEFAULT_TIMEOUT_MS` on accepted connections (`GameConnector`, `GameHost`), so a client with a longer timeout is always outlived by its own server. A stalled client then gets killed by the server rather than detecting the problem itself.

Restoring the short value after login keeps both ends symmetric during play, which is where that matters.

## Reconnect

Handled for free: `connectSocket()` sets the login value on the new socket, and `run()` re-enters the login block, which restores the normal timeout again.

## Verifying

Join a game with a large saved state — one whose `masterData` → `gameData` diff takes more than ten seconds to transfer. Before this change the client dies with `SocketTimeoutException` partway through loading; after, the sync completes and play proceeds with the normal 10-second timeout in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)