### PR TITLE
Fix: a run-time rename never propagated as its own change

### DIFF
--- a/game/utility/game_objects/source/com/robin/game/objects/GameObject.java
+++ b/game/utility/game_objects/source/com/robin/game/objects/GameObject.java
@@ -99,7 +99,7 @@ public class GameObject extends ModifyableObject implements Serializable {
 		// during the loop are harmless - we are not reading the field, only writing it once done.
 		GameObject local = new GameObject();
 		local.id = this.id;
-		local.setName(name); // so that keyval searches with name actually work!!
+		local._setName(name); // so that keyval searches with name actually work!!  (raw: detached snapshot)
 		local._setVersion(version);
 		for (String blockName : attributeBlocks.keySet()) {
 			OrderedHashtable<String,OrderedHashtable> attributes = attributeBlocks.get(blockName);
@@ -1110,7 +1110,10 @@ public class GameObject extends ModifyableObject implements Serializable {
 	}
 
 	public void revertNameToDefault() {
-		setName("GameObject"); // default name
+		// Raw: naming a brand new object is initialization, not a rename.  Going through setName() here
+		// would make every createNewObject() - including the one a client does while APPLYING an
+		// incoming change - emit a carrier change of its own.
+		_setName("GameObject"); // default name
 	}
 
 	public void setAttribute(String blockName, String key) {
@@ -1333,13 +1336,46 @@ public class GameObject extends ModifyableObject implements Serializable {
 		this.id = newid;
 	}
 
+	/**
+	 * Rename this object.
+	 *
+	 * A rename is the only mutation that is NOT represented by its own GameObjectChange.  Every change
+	 * carries the object's name as it stood when that change was CONSTRUCTED (see
+	 * GameObjectChange's constructor), and the receiving side re-applies it - so historically a rename
+	 * only reached other clients by riding along on whatever unrelated change happened to be built
+	 * next, and the result depended on replay order.
+	 *
+	 * That is fine for an object that is named once at setup and never renamed, which is almost
+	 * everything.  It is NOT fine for objects created at run time and named immediately afterwards -
+	 * e.g. generated monsters, where MonsterCreator.createOrReuseMonster() hands back either a recycled
+	 * corpse (already correctly named, so every change carries the right name) or a brand new object
+	 * still called "GameObject".  In the new-object case the earliest changes carry "GameObject", and a
+	 * replay that stops short of a later change leaves the monster permanently misnamed.
+	 *
+	 * So: emit a carrier change at the moment of the rename.  GameBumpVersionChange does nothing itself,
+	 * but it is constructed AFTER the field is updated, so it captures the new name and the base class
+	 * applies it on the receiving side - making the rename a first-class, correctly ordered event.
+	 */
 	public void setName(String val) {
+		if (val != null && !val.equals(name)) {
+			_setName(val);
+			if (parent != null && parent.isTracksChanges()) {
+				parent.addChange(new GameBumpVersionChange(this)); // carries the NEW name
+			}
+		}
+	}
+
+	/**
+	 * Raw rename with no change emitted.  Used when APPLYING a change that already carries a name, so
+	 * that a receiving client does not echo a fresh change straight back at the sender.
+	 */
+	public void _setName(String val) {
 		if (val != null && !val.equals(name)) {
 			// Since name is changing, so is the way it should be hashed by its parent.  Fix that!
 			if (parent!=null) {
 				parent.changingName(name,val,this);
 			}
-			
+
 			name = val;
 			setModified(true);
 		}

--- a/game/utility/game_objects/source/com/robin/game/objects/GameObjectChange.java
+++ b/game/utility/game_objects/source/com/robin/game/objects/GameObjectChange.java
@@ -69,7 +69,7 @@ public abstract class GameObjectChange implements Serializable {
 		if (go==null) {
 			go = data.createNewObject(id);
 		}
-		go.setName(name);
+		go._setName(name); // raw: applying a change must not emit a fresh change back at the sender
 		go._setVersion(version);
 		applyChange(data,go);
 	}


### PR DESCRIPTION
### The problem

`GameObject.setName()` is the only mutation with no `GameObjectChange` behind it.

Every change carries the object's name **as captured when that change was constructed** (`GameObjectChange`'s constructor), and the receiving side re-applies it in `applyChange(GameData)`. So a rename only ever reached other machines by riding along on whatever unrelated change happened to be built next — and whether it arrived depended on replay order.

That is harmless for an object named once at setup and never renamed, which is almost everything. It breaks objects **created at run time and named immediately afterwards**.

`MonsterCreator.createOrReuseMonster()` returns either:
- a recycled corpse — already correctly named, so every subsequent change carries the right name; or
- a brand new object still called `"GameObject"`, where the earliest changes carry `"GameObject"` and only later ones carry the real name.

In the second case a replay that stops short leaves the object permanently misnamed.

### How it shows up

Generated monsters (Pond/Hive/Tomb spawns) named `GameObject` instead of `Blob`/`Wasp`/`Skeleton`, sitting alongside correctly named siblings. Observed in a saved game with **every** `setThisAttribute()` from `MonsterCreator.setupGameObject()` applied and only the name missing — which is what pointed at `setName()` as the one call not going through the change machinery.

### The fix

- `setName()` now emits a `GameBumpVersionChange` carrier, constructed *after* the field is updated so it captures the **new** name. The rename becomes a first-class, correctly ordered event in the stream. `GameBumpVersionChange` already exists for exactly this purpose — `setHeldBy()` uses it the same way — so **no new change type enters the network protocol**.
- New `_setName()`: raw rename, no change emitted, following the existing `_setAttribute()` / `_setVersion()` convention in this class.
- `GameObjectChange.applyChange()` and `revertNameToDefault()` use `_setName()`, so a receiving client does not echo a fresh change back at the sender, and `createNewObject()` does not emit a spurious change of its own.

Two files, +40/-4.

### Verification

A harness reproducing the `createOrReuseMonster` → `createBlob` call order and replaying the change stream host→client. The emitted stream is now:

```
#1  GameObject (#0 version 0):  Sets [this:number] = 12
#2  Blob (#0 version 1): Bump data version to force redraw   <- the rename, explicit
#3  Blob (#0 version 1):  Sets [this:monster] =
```

Checks: full replay; **partial replay stopping at the rename** (the actual failure mode); no echo when applying to a tracking client; no change when re-setting the same name. All pass.

Also play-tested host + client: six newly spawned monsters all correctly named on both machines, including after the client disconnected and rejoined (a fresh join replays the stream from scratch, which is the case this targets). Pre-existing misnamed monsters in an old save stay misnamed — the fix prevents new breakage, it does not repair stored data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)