### PR TITLE
Fix NPE in actionIsValid when a character has no location

### DIFF
--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/wrapper/CharacterWrapper.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/wrapper/CharacterWrapper.java
@@ -2839,7 +2839,7 @@ public class CharacterWrapper extends GameObjectWrapper {
 		}
 		if (id==ActionId.Offroad) {
 			HostPrefWrapper hostPrefs = HostPrefWrapper.findHostPrefs(getGameObject().getGameData());
-			if (location.isBetweenClearings() && hostPrefs.hasPref(Constants.EXP_OFFROAD_TRAVEL_NO_ROADWAYS)) {
+			if (location!=null && location.isBetweenClearings() && hostPrefs.hasPref(Constants.EXP_OFFROAD_TRAVEL_NO_ROADWAYS)) {
 				return false;
 			}
 			return hostPrefs.hasPref(Constants.EXP_OFFROAD_TRAVEL);


### PR DESCRIPTION
### Problem

`CharacterWrapper.actionIsValid()` throws when called with a null `location` and the action is `Offroad`:

```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException:
  Cannot invoke "TileLocation.isBetweenClearings()" because "location" is null
    at CharacterWrapper.actionIsValid(CharacterWrapper.java:2842)
    at CharacterActionControlManager.willBeRed(CharacterActionControlManager.java:964)
    at CharacterActionControlManager.updateControls(CharacterActionControlManager.java:924)
    at CharacterActionPanel.updateControls(CharacterActionPanel.java:143)
    at CharacterFrame.updateControls(CharacterFrame.java:1835)
    at CharacterFrame.toFront(CharacterFrame.java:1764)
    at RealmGameHandler.showNextRecordFrame(RealmGameHandler.java:2530)
    at CharacterActionControlManager.doFinish(CharacterActionControlManager.java:515)
```

The method already treats a null `location` as an expected input everywhere else — the Move/Offroad tile-only test, the `Fly` test and the `EnhPeer` branch each guard with `location!=null`. Only the `Offroad` branch dereferences it directly.

### This is not gated behind the offroad optional rules

Worth noting, since the branch looks at first glance like it only runs for players using offroad travel:

- `updateControls()` calls `willBeRed(pm, DayAction.OFFROAD_TRAVEL_ACTION, usingPony, planned)` **unconditionally** on every refresh, to decide whether to grey out the Offroad button. So `actionIsValid` is entered with `id==Offroad` for every character, every time, whatever they are doing.
- `&&` evaluates left to right, so `location.isBetweenClearings()` runs *before* `hostPrefs.hasPref(EXP_OFFROAD_TRAVEL_NO_ROADWAYS)`. Neither offroad host pref needs to be enabled for the NPE to fire.

Nothing earlier in the method returns first for this case either: the `ONLY_MOVE` and tile-only tests both explicitly exclude `Offroad`, and the `Fly` tests do not apply. So `id==Offroad` with a null location falls straight into the dereference.

### Why the null is legitimate

`CharacterActionControlManager.updateControls()` computes

```java
TileLocation planned = getCharacter().getPlannedLocation();
```

then null-checks it three times over (`finishAction`, `inCave`, `inWater`) before passing that same value into `actionIsValid` through seventeen `willBeRed()` call sites. `getPlannedLocation()` returns `getCurrentLocation()`, which is null for any character not on the map.

### Reproduction

1. A character dies during the day. The death path calls `ClearingUtility.moveToLocation(getGameObject(), null)`, so its location becomes null — but `DO_RECORD` is left set (only `doFinish()` and one minion path ever clear it).
2. Another player clicks **Finish**. `doFinish()` calls `showNextRecordFrame()`, which selects on `isDoRecord()` alone — and `isDoRecord()`'s `canPlay()` gate only excludes familiars, not dead characters — so the dead character's frame comes to the front.
3. `updateControls()` runs for it, `planned` is null, and the `Offroad` branch throws.

### Fix

```diff
-if (location.isBetweenClearings() && hostPrefs.hasPref(Constants.EXP_OFFROAD_TRAVEL_NO_ROADWAYS)) {
+if (location!=null && location.isBetweenClearings() && hostPrefs.hasPref(Constants.EXP_OFFROAD_TRAVEL_NO_ROADWAYS)) {
```

With no location there is no roadway to be on, so the guard skips only the roadway restriction and falls through to the ordinary `EXP_OFFROAD_TRAVEL` test — matching how the neighbouring branches handle a null location.

Note this fixes the crash only. That a dead character stays in the recording rotation at all looks like a separate issue, and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)