### PR TITLE
Drop dead and departed characters out of the recording rotation

### DIFF
--- a/magic_realm/utility/components/source/com/robin/magic_realm/components/wrapper/CharacterWrapper.java
+++ b/magic_realm/utility/components/source/com/robin/magic_realm/components/wrapper/CharacterWrapper.java
@@ -528,9 +528,18 @@ public class CharacterWrapper extends GameObjectWrapper {
 	public int getCombatCount() {
 		return getInt(COMBAT_COUNT);
 	}
+	/**
+	 * A character is recording only while it is still in the game.  Nothing clears DO_RECORD when a
+	 * character leaves - makeDead() and makeGone() both null the location without touching the flag,
+	 * and only doFinish() and the minion path in RealmHostPanel ever call setDoRecord(false) - so the
+	 * flag stays set on a character that died partway through its own turn.  Filtering here rather
+	 * than at each call site keeps every consumer consistent and covers any future removal path;
+	 * otherwise showNextRecordFrame() brings a dead character's action panel to the front whenever
+	 * anyone else finishes their turn.
+	 */
 	public boolean isDoRecord() {
 		if (getBoolean(DO_RECORD)) {
-			return canPlay();
+			return isActive() && canPlay();
 		}
 		return false;
 	}


### PR DESCRIPTION
### Problem

Nothing clears `DO_RECORD` when a character leaves the game.

- `makeDead()` and `makeGone()` both null the character's location, but neither touches the flag.
- The only two `setDoRecord(false)` calls in the codebase are `CharacterActionControlManager.doFinish()` and the minion path in `RealmHostPanel`.
- `isDoRecord()` doesn't filter it either — its `canPlay()` gate excludes only familiars, not the dead.

So a character that dies partway through its own turn keeps `DO_RECORD` set for the rest of the day.

### Visible effect

`RealmGameHandler.showNextRecordFrame()` selects on `isDoRecord()` alone:

```java
for (CharacterFrame frame : characterFrames.values()) {
    CharacterWrapper character = frame.getCharacter();
    if (character.isDoRecord()) {
```

so when any player clicks **Finish**, a **dead** character's action panel can be brought to the front.

It is also the state behind a crash in `CharacterWrapper.actionIsValid()` — the `Offroad` branch dereferences a null `location`, and `updateControls()` reaches it for a character whose location `makeDead()` has already nulled. That NPE is fixed separately in #47; this removes the reason it is being reached.

### Fix

```diff
 public boolean isDoRecord() {
     if (getBoolean(DO_RECORD)) {
-        return canPlay();
+        return isActive() && canPlay();
     }
     return false;
 }
```

Filtered in `isDoRecord()` rather than by clearing the flag in `makeDead()`/`makeGone()`, so every consumer stays consistent and any future removal path is covered without having to remember this.

`canPlay()` is deliberately left alone — `RealmGameHandler` and `RealmHostPanel` both call it independently of recording, so widening it would reach past this bug.

### Corroboration

Two call sites already hand-write the guard:

```java
// CharacterActionControlManager
boolean canUnsend = getCharacter().isActive() && birdsong && !getCharacter().isDoRecord();

// CharacterHirelingPanel
assignUnderlings.setEnabled(getCharacter().isActive() && getCharacter().isDoRecord() && ...);
```

which is what the missing filter looks like from the outside. They are redundant after this change but harmless, so they are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)