### PR TITLE
Close the character window when a character dies on its own client

### DIFF
--- a/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
+++ b/magic_realm/applications/RealmSpeak/source/com/robin/magic_realm/RealmSpeak/CharacterFrame.java
@@ -1036,10 +1036,15 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 				// Now what?
 				JOptionPane.showMessageDialog(gameHandler.getMainFrame(), "You have died of weather fatigue.", "Dead", JOptionPane.INFORMATION_MESSAGE);
 				character.makeDead("Died by weather fatigue");
-				// I doubt this is enough...
 			}
 			gameHandler.submitChanges();
 			gameHandler.updateCharacterFrames();
+			// updateCharacterFrames() skips frames whose character is no longer isActive(), so a
+			// character that just died is never refreshed again - its "Fatigue to Continue" button
+			// keeps whatever state it last had.  Only updateCharacterList() removes the frame, and
+			// without this call that does not happen until some later server-driven change reaches
+			// updateGameHandler(), leaving a frozen window behind in the meantime.
+			gameHandler.updateCharacterList(); // This is necessary so that THIS client is updated
 		}
 	}
 	protected void checkDenizenControlToContinue() {
@@ -1070,10 +1075,12 @@ public class CharacterFrame extends RealmSpeakInternalFrame implements ICharacte
 				// Now what?
 				JOptionPane.showMessageDialog(gameHandler.getMainFrame(), "You have died of your wounds.", "Dead", JOptionPane.INFORMATION_MESSAGE);
 				character.makeDead("Died of wounds.");
-				// I doubt this is enough...
 			}
 			gameHandler.submitChanges();
 			gameHandler.updateCharacterFrames();
+			// See fatigueToContinue():  the dying character's frame is skipped by
+			// updateCharacterFrames() and only updateCharacterList() will remove it.
+			gameHandler.updateCharacterList(); // This is necessary so that THIS client is updated
 		}
 	}
 	


### PR DESCRIPTION
### Problem

A character that dies of wounds or weather fatigue leaves its window on screen — frozen, with the **Wound to Continue** / **Fatigue to Continue** button still showing — until some unrelated later change happens to reach the client. In a multiplayer game that can be as late as every other player finishing their turn.

### Cause

The frame falls between two methods.

`updateCharacterFrames()` — which both death paths call — skips inactive characters:

```java
for (CharacterFrame frame : characterFrames.values()) {
    if (frame.getCharacter().isActive()) {   // just marked DEAD → skipped
        frame.updateCharacter();
    }
}
```

So the dying character's own frame is never refreshed again. Note the button already knows how to hide itself:

```java
woundButton = new SingleButton("Wound to Continue",true) {
    public boolean needsShow() {
        boolean extraWounds = getCharacter().getExtraWounds()>0;
        return character.isActive() && character.isCharacter() && extraWounds;
    }
};
```

`character.isActive()` is right there — `needsShow()` is simply never asked again.

`updateCharacterList()` is what actually *removes* a dead character's frame:

```java
else if (character.isDead()) {
    // Need to remove the frame from play...
    characterFrames.remove(id);
    characterFrameOrder.remove(id);
    parent.removeFrameFromDesktop(frame);
```

…but neither death path calls it. It only runs on the next server-driven `updateGameHandler()`.

The window is therefore orphaned: too dead to refresh, not removed because nothing asked for removal.

### Fix

Add `updateCharacterList()` to both death paths in `CharacterFrame` — `fatigueToContinue()` and `woundToContinue()`.

**Added rather than substituted** for `updateCharacterFrames()`: `updateCharacterList()` does not redraw the map, and a death takes a token off the board.

This is the same remedy, with the same comment, already applied at three other places in this same file where a locally-originated change had to be reflected on the client that made it:

```java
gameHandler.updateCharacterList(); // This is necessary so that THIS client is updated
```

The two death sites appear to be the ones that were missed — which is presumably what the `// I doubt this is enough...` markers were about. Those markers are removed, since it now is.

### Relationship to #47 and #48

This is the root cause behind both. A dead character lingering in client state with its location already nulled is what let `updateControls()` reach the `Offroad` NPE (#47) and what left it in the recording rotation (#48). Those two are still worth having on their own — this one stops the state arising in the first place.

The three are independent branches off master and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)