### PR TITLE
Stop CombatSummarySheet leaking a button on every repaint

### DIFF
--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatSummarySheet.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatSummarySheet.java
@@ -69,6 +69,10 @@ public class CombatSummarySheet extends JPanel {
 	private int buttonHeight = 20;
 	public void paintComponent(Graphics g1) {
 		super.paintComponent(g1);
+		// The Sheet/Lure/Flip buttons below are created and added during the paint, so without this
+		// every repaint leaks another set - thousands of them after a while, until the event thread
+		// spends all its time painting button text
+		removeAll();
 		g1.setFont(STAGE_FONT);
 		Graphics2D g = (Graphics2D)g1;
 		AffineTransform normal = g.getTransform();


### PR DESCRIPTION
`CombatSummarySheet.paintComponent()` creates the **Sheet** button for each participant — plus **Lure** and **Flip** during the lure step — and `add()`s them to the panel, but nothing ever removes them. Every repaint stacks another set on top, and Swing then has to lay out and paint all of them.

After roughly 18 minutes of a battle with the summary pane selected, a heap histogram shows:

```
javax.swing.JButton                   32,057 instances
AquaButtonUI$AquaButtonListener       32,317
javax.swing.event.EventListenerList  100,074
```

with the event thread parked in `AquaButtonUI.paintText` under `paintChildren`.

The window becomes progressively slower and eventually appears frozen. It only seems to recover when nothing is repainting, which is why it can look intermittent.

Anything that repaints the pane repeatedly will trigger it — scrolling, mouse movement over the panel, or opening and closing the Round Summary dialog on top of it.

**Fix:** `removeAll()` before rebuilding, bounding the count to one set per paint.

Worth noting the deeper issue is that `paintComponent` mutates the component tree at all. Rebuilding the buttons only when the participant list or action state changes would be cleaner, but it is a much larger change; this keeps the diff to the actual leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)