### PR TITLE
Fix NPE clicking Next when a character has no location

### DIFF
--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
@@ -1448,7 +1448,10 @@ public class CombatFrame extends JFrame {
 			boolean hasHirelings = false;
 			if (!hasEnemies) {
 				for (RealmComponent hireling : character.getAllHirelings()) {
-					if (loc.toString().matches(hireling.getCurrentLocation().toString())) {
+					// A character that has run away can be left with no location at all, and a
+					// hireling may have none either - neither can then share a clearing with anyone
+					TileLocation hirelingLoc = hireling.getCurrentLocation();
+					if (loc!=null && hirelingLoc!=null && loc.toString().matches(hirelingLoc.toString())) {
 						hasHirelings = true;
 						if (new CombatWrapper(hireling.getGameObject()).getAttackerCount()>0) {
 							attackers.addAll(new CombatWrapper(hireling.getGameObject()).getAttackers());
@@ -1463,7 +1466,10 @@ public class CombatFrame extends JFrame {
 				boolean hidden = character.isHidden();
 				boolean attackingEnemies = true;
 				for (RealmComponent hireling : character.getAllHirelings()) {
-					if (loc.toString().matches(hireling.getCurrentLocation().toString())) {
+					// A character that has run away can be left with no location at all, and a
+					// hireling may have none either - neither can then share a clearing with anyone
+					TileLocation hirelingLoc = hireling.getCurrentLocation();
+					if (loc!=null && hirelingLoc!=null && loc.toString().matches(hirelingLoc.toString())) {
 						if (!hireling.isHidden()) {
 							hidden = false;
 						}


### PR DESCRIPTION
A character that has run away can be left with no current location. `doNext()` dereferences it immediately to compare clearings with any hirelings, so the click dies before any phase logic runs:

```
NullPointerException: Cannot invoke "TileLocation.toString()" because "loc" is null
    at CombatFrame.doNext(CombatFrame.java:1451)
```

Combat then cannot advance at all — every subsequent **Next** throws in the same place. Because the exception escapes to the event thread, which then goes back to idle, it presents as a freeze rather than an error, and the combat is unrecoverable without reloading.

**Reproduced** in the Battle Builder: lure denizens with a character, then run away. Saving the combat and reloading it recovers the state, since nothing is corrupted — the exception happens before any state change.

**Fix:** guard both call sites. A hireling may equally have no location, so that is checked too; if either is missing they cannot be sharing a clearing, which is the correct answer rather than a workaround.

There is a second site a few lines below with the identical construct, which would have thrown on the very next step, so both are guarded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)