### PR TITLE
Fix false "No attack chit placed" warning when the target sits on a third party's sheet

### DIFF
--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
@@ -1436,6 +1436,27 @@ public class CombatFrame extends JFrame {
 			doFatigueWounds(this,activeCharacter);
 		}
 	}
+	/**
+	 * True when a placed attack chit will land on the given target, judged by the sheet it was
+	 * placed on.
+	 * <p>
+	 * A target that owns a sheet is attacked on its own sheet.  A denizen that owns no sheet is
+	 * displayed alongside whoever IT is attacking, which is often a DIFFERENT character than the
+	 * one attacking it - so the attack chit is placed on that third party's sheet, and comparing
+	 * the sheet to either the target or the attacker misses it.  See CombatSheet.updateLayout,
+	 * which places a participant on a sheet when its target's target is already on that sheet.
+	 */
+	private static boolean attackReachesTarget(CombatWrapper placedChit,RealmComponent target) {
+		if (target==null || !placedChit.getPlacedAsFight()) return false;
+		String sheetId = placedChit.getSheetOwnerId();
+		if (sheetId==null) return false;
+		if (sheetId.equals(target.getGameObject().getStringId())) return true;
+		RealmComponent targetsTarget = target.getTarget();
+		if (targetsTarget!=null && sheetId.equals(targetsTarget.getGameObject().getStringId())) return true;
+		RealmComponent targetsTarget2 = target.get2ndTarget();
+		if (targetsTarget2!=null && sheetId.equals(targetsTarget2.getGameObject().getStringId())) return true;
+		return false;
+	}
 	private void doNext() {
 		if (combatNextPhaseWarning) {
 			String warning = null;
@@ -1541,13 +1562,13 @@ public class CombatFrame extends JFrame {
 							combatChits.add(monsterCombat);
 						}
 						for (CombatWrapper combat : combatChits) {
-							if (target1!=null && combat.getPlacedAsFight() && combat.getSheetOwnerId().matches(target1.getGameObject().getStringId())) {
+							if (attackReachesTarget(combat,target1)) {
 								attacksTarget1 = true;
 							}
-							if (target2!=null && combat.getPlacedAsFight() && combat.getSheetOwnerId().matches(target2.getGameObject().getStringId())) {
+							if (attackReachesTarget(combat,target2)) {
 								attacksTarget2 = true;
 							}
-							if (combat.getPlacedAsFight() && combat.getSheetOwnerId().matches(character.getGameObject().getStringId())) {
+							if (combat.getPlacedAsFight() && character.getGameObject().getStringId().equals(combat.getSheetOwnerId())) {
 								if (target1!=null && !(new CombatWrapper(target1.getGameObject())).isSheetOwner()) {
 									attacksTarget1 = true;
 								}


### PR DESCRIPTION
At the Positioning step, `doNext()` warns that no attack chit was placed on the target's sheet. The check accepted a placed fight chit in only two situations: the chit was on the **target's own** sheet, or on the **attacking character's own** sheet.

It misses the common case where the target is a denizen that owns no sheet. Such a denizen is displayed alongside whoever *it* is attacking, which is often a different character than the one attacking it — so the attack chit is correctly placed on that third party's sheet. The sheet owner recorded on the chit is then neither the target nor the attacker, both tests fail, and the player is warned even though the chit was placed properly.

**Repro:** Woods Girl targets an Axe Goblin that is attacking the Amazon. The goblin is shown on the Amazon's sheet, so Woods Girl's fight chit is placed there and records the Amazon as its sheet owner. Neither test matches, and "No attack chit placed" appears despite a correctly placed chit.

`CombatSheet.updateLayout` already knows this rule — it places a participant on a sheet when its target's target is already on that sheet. The warning check never learned it. `attackReachesTarget()` applies the same rule, and the two existing branches are left intact so nothing that passed before changes behaviour; only the false positive goes away.

Also replaces `String.matches()`, which treats its argument as a regular expression, with `String.equals()` for the id comparison.

**Tested:** target on a third party's sheet (no warning, was the bug); target owning its own sheet and target on the attacker's own sheet (no warning — both original branches still pass); target selected with no chit placed, and a chit placed where it cannot reach the target (warning still fires); second target and transmorphed character paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)