### PR TITLE
Fix Combat Summary pane scroll responsiveness

### DIFF
--- a/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
+++ b/magic_realm/applications/RealmBattle/source/com/robin/magic_realm/RealmBattle/CombatFrame.java
@@ -1634,7 +1634,11 @@ public class CombatFrame extends JFrame {
 					CombatSummarySheet combatSummarySheet = new CombatSummarySheet(this);
 					int height = 400+allParticipants.size()*(PARTICIPANT_ROW_HEIGHT+PARTICIPANT_ROW_HEIGHT/2);
 					combatSummarySheet.setPreferredSize(new Dimension(600,height));
-					combatSheetPanel.add(new JScrollPane(combatSummarySheet));
+					JScrollPane summaryScroll = new JScrollPane(combatSummarySheet);
+					summaryScroll.getVerticalScrollBar().setUnitIncrement(20);
+					summaryScroll.getHorizontalScrollBar().setUnitIncrement(20);
+					combatSheetPanel.add(summaryScroll);
+					SwingUtilities.invokeLater(summaryScroll.getViewport()::requestFocusInWindow);
 				}
 				else {
 					RealmComponent rc = allParticipants.get(row-1);


### PR DESCRIPTION
## Summary

- `CombatSummarySheet` does not implement `Scrollable`, so `JScrollPane` defaults to a 1-pixel unit increment. Arrow-key scrolling was nearly imperceptible as a result.
- Set the unit increment to 20 px on both scroll bars so each arrow key press produces a visible scroll.
- Request focus on the viewport (via `invokeLater`) immediately after the summary is shown, so arrow keys scroll the summary pane rather than re-selecting rows in the participant table.

## Test plan
- [x] Open Combat Summary pane (click Summary row at top of participant list)
- [x] Verify up/down arrow keys scroll the pane smoothly
- [x] Verify mouse-wheel scroll works proportionally
- [x] Verify clicking a participant row after viewing summary still switches the sheet correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)