### PR TITLE
Fix GameServer doBroadcast null race causing client crash

### DIFF
--- a/game/utility/game_server/source/com/robin/game/server/GameServer.java
+++ b/game/utility/game_server/source/com/robin/game/server/GameServer.java
@@ -71,12 +71,13 @@ public class GameServer extends GameNet {
 		}
 		return null;
 	}
-	private void doBroadcast() throws IOException {
+	private boolean doBroadcast() throws IOException {
 		String[] string = getNextBroadcast();
+		if (string == null) return false; // list emptied between isBroadcast() and remove(); caller sends IDLE
 		getOutputStream().writeInt(RESPOND_BROADCAST);
 		getOutputStream().writeObject(string);
 		flush();
-		// no feedback needed
+		return true;
 	}
 	public void addInfoDirect(InfoObject io) {
 		infoDirects.add(io);
@@ -171,8 +172,8 @@ public class GameServer extends GameNet {
 				else if (isInfoDirect()) {
 					doInfoDirect();
 				}
-				else if (isBroadcast()) {
-					doBroadcast();
+				else if (isBroadcast() && doBroadcast()) {
+					// broadcast sent
 				}
 				else if (shuttingDown) {
 					getOutputStream().writeInt(RESPOND_GOODBYE);


### PR DESCRIPTION
## Problem

`doBroadcast()` is reached via this path in `processNextRequest()`:

```java
else if (isBroadcast()) {
    doBroadcast();
}
```

`isBroadcast()` checks `!broadcasts.isEmpty()` and returns true. But the `broadcasts` `ArrayList` is written by the host thread (via `broadcast()`) and read/removed by the per-client server thread — no synchronization. If the list is emptied between the `isBroadcast()` check and the `broadcasts.remove(0)` call inside `getNextBroadcast()`, `getNextBroadcast()` returns `null`.

The original `doBroadcast()` passed that `null` directly to `writeObject()`, sending a null `String[]` to the client. The client's deserialization throws an NPE, kills the connection, and the server hangs waiting for a client that is gone.

A secondary problem: even with an early-return null guard, `doBroadcast()` would return without writing anything to the client, leaving the client blocked on `readInt()` waiting for a response that never comes.

## Fix

Change `doBroadcast()` to return `boolean` — `true` if a broadcast was sent, `false` if the list turned out to be empty. `processNextRequest()` treats `false` the same as the no-broadcast case and falls through to send `RESPOND_IDLE`, keeping the request/response protocol intact and the client's connection healthy.

## Test

Reproduced as a multiplayer session freeze during combat; confirmed fix resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)